### PR TITLE
Add pyproject and dynamic settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,36 @@ docs/_build/
 *.nii
 *.nii.gz
 *.png
+# model weights and caches
+*.h5
+*.ckpt
+*.pt
+*.pth
+weights/
+checkpoints/
+
+# downloaded resources
+atlas*/
+*.zip
+*.tar.gz
+
+# large imaging data
+dicom_dump/
+*.dcm
+tmp_nifti/
+
+# notebook and coverage artifacts
+.ipynb_checkpoints/
+coverage.xml
+
+# compiled extensions
+*.so
+*.pyd
+*.c
+*.cpp
+
+# container metadata
+docker-compose.yml
+*.env.docker
+k8s/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,16 @@ repos:
     rev: 6.1.0
     hooks:
       - id: flake8
+        additional_dependencies:
+          - flake8-bugbear
+          - flake8-comprehensions
+        args: [--max-complexity=10]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.6.1
     hooks:
       - id: mypy
         additional_dependencies: [types-Pillow, types-pydicom]
+        args: [--strict]
   - repo: https://github.com/pycqa/bandit
     rev: 1.7.5
     hooks:

--- a/msk_io/__main__.py
+++ b/msk_io/__main__.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import typer
 from rich.console import Console
 from .api import run_pipeline
-from .config import PipelineConfig
+from .config import PipelineSettings
 
 app = typer.Typer(add_completion=False)
 console = Console()
@@ -17,7 +17,7 @@ def run(
     dry_run: bool = typer.Option(False, "--dry-run"),
 ):
     """Execute full pipeline."""
-    conf = PipelineConfig(rules_path=config, verbose=verbose)
+    conf = PipelineSettings(rules_path=config, verbose=verbose)
     if dry_run:
         console.print(f"[yellow]Dry run with config: {conf}")
         raise typer.Exit()

--- a/msk_io/api.py
+++ b/msk_io/api.py
@@ -10,6 +10,7 @@ from .symbolic.symbolic_state_emitter import SymbolicStateEmitter, SymbolicState
 from .inference.constraint_lattice import ConstraintLattice
 from .control.multi_agent_harmonizer import MultiAgentHarmonizer, AgentOutput
 from .storage.memory_vault import MemoryVault
+from .config import PipelineSettings
 from .errors import (
     DICOMLoadError,
     NiftiConversionError,
@@ -45,7 +46,7 @@ class PipelineRunner:
         self.harmonizer = harmonizer or MultiAgentHarmonizer()
         self.vault = vault
 
-    def run(self, dicom_dir: Path, config_path: Path, vault_path: Path) -> dict:
+    def run(self, dicom_dir: Path, config: PipelineSettings, vault_path: Path) -> dict:
         try:
             volume = self.loader.load_series(dicom_dir)
         except Exception as exc:
@@ -77,7 +78,7 @@ class PipelineRunner:
             raise EmissionError(str(exc)) from exc
 
         try:
-            lattice = self.lattice or ConstraintLattice(config_path)
+            lattice = self.lattice or ConstraintLattice(config.rules_path)
             valid = lattice.validate_chain([state])
         except Exception as exc:
             raise ConstraintValidationError(str(exc)) from exc
@@ -102,6 +103,6 @@ class PipelineRunner:
         }
 
 
-def run_pipeline(dicom_dir: Path, config_path: Path, vault_path: Path) -> dict:
+def run_pipeline(dicom_dir: Path, config: PipelineSettings, vault_path: Path) -> dict:
     runner = PipelineRunner()
-    return runner.run(dicom_dir, config_path, vault_path)
+    return runner.run(dicom_dir, config, vault_path)

--- a/msk_io/config.py
+++ b/msk_io/config.py
@@ -1,14 +1,47 @@
 from pathlib import Path
-from pydantic import BaseModel, Field, validator
+from threading import Thread
+from typing import Callable, Optional
+
+from pydantic import Field, ValidationError, field_validator
+from pydantic_settings import BaseSettings
 
 
-class PipelineConfig(BaseModel):
+class PipelineSettings(BaseSettings):
+    """Pipeline hyperparameters loaded from environment or file."""
+
     rules_path: Path = Field(..., description="Path to lattice rules JSON")
     threshold: float = Field(0.5, ge=0.0, le=1.0)
+    patch_size: int = Field(64, gt=0)
+    stride: int = Field(32, gt=0)
+    atlas_path: Optional[Path] = None
     verbose: bool = False
 
-    @validator("rules_path")
+    model_config = dict(env_prefix="MSK_", extra="ignore")
+
+    @field_validator("rules_path")
+    @classmethod
     def check_rules(cls, v: Path) -> Path:
         if not v.exists():
             raise FileNotFoundError(v)
         return v
+
+
+def start_settings_watcher(path: Path, callback: Callable[[PipelineSettings], None]) -> Thread:
+    """Start a watchdog thread that reloads settings on file changes."""
+    from watchdog.events import FileSystemEventHandler
+    from watchdog.observers import Observer
+
+    class _Handler(FileSystemEventHandler):
+        def on_modified(self, event):
+            if Path(event.src_path) == path:
+                try:
+                    settings = PipelineSettings.model_validate_json(path.read_text())
+                    callback(settings)
+                except ValidationError as exc:
+                    print(f"Config reload failed: {exc}")
+
+    observer = Observer()
+    observer.schedule(_Handler(), path.parent, recursive=False)
+    thread = Thread(target=observer.start, daemon=True)
+    thread.start()
+    return thread

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=61", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "msk-io"
+dynamic = ["version"]
+description = "Medical imaging toy pipeline"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [{name = "MSK", email="noreply@example.com"}]
+requires-python = ">=3.11"
+dependencies = [
+    "numpy",
+    "pydantic>=2",
+    "pydicom",
+    "nibabel",
+    "Pillow",
+    "typer",
+]
+
+[project.optional-dependencies]
+gpu = ["cupy"]
+cli = ["rich"]
+dev = ["pytest", "black", "flake8", "mypy"]
+
+[tool.setuptools]
+packages = ["msk_io"]
+
+[tool.setuptools_scm]
+version_scheme = "post-release"
+local_scheme = "no-local-version"
+

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import json
+from msk_io.config import PipelineSettings
+
+
+def test_env_loading(tmp_path, monkeypatch):
+    cfg = tmp_path / "rules.json"
+    cfg.write_text(json.dumps({}))
+    monkeypatch.setenv("MSK_RULES_PATH", str(cfg))
+    monkeypatch.setenv("MSK_THRESHOLD", "0.7")
+    settings = PipelineSettings()
+    assert settings.rules_path == cfg
+    assert settings.threshold == 0.7


### PR DESCRIPTION
## Summary
- expand repo ignore rules for DICOM and model artifacts
- enforce stricter pre-commit hooks
- move packaging to `pyproject.toml`
- add pydantic `PipelineSettings` with watchdog reload helper
- adjust CLI and API to use new settings
- test configuration loading from env

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d5a864f90832fac783b4b50c98fa7