### PR TITLE
Refactor pipeline configuration and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,26 @@
 __pycache__/
+**/__pycache__/
 *.pyc
-# virtualenvs
+# virtualenvs and environments
 venv/
+.venv/
 .env
+.env.*
 
 # py test caches
 .pytest_cache/
 .mypy_cache/
 
+# generic cache
+.cache/
+
 # coverage files
 .coverage
 htmlcov/
+coverage/
+
+# log files
+*.log
 
 # build artifacts
 build/
@@ -35,6 +45,14 @@ docs/_build/
 *.pth
 weights/
 checkpoints/
+model_cache/
+
+# local credentials
+*.key
+*.pem
+*.crt
+secrets.yml
+secrets.toml
 
 # downloaded resources
 atlas*/
@@ -60,4 +78,5 @@ coverage.xml
 docker-compose.yml
 *.env.docker
 k8s/
+docker/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
         additional_dependencies:
           - flake8-bugbear
           - flake8-comprehensions
+          - flake8-bandit
         args: [--max-complexity=10]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.6.1

--- a/msk_io/__main__.py
+++ b/msk_io/__main__.py
@@ -1,39 +1,69 @@
+from __future__ import annotations
+
+import logging
 from pathlib import Path
+from typing import Optional
+
 import typer
 from rich.console import Console
-from .api import run_pipeline
-from .config import PipelineSettings
+from rich.logging import RichHandler
 
-app = typer.Typer(add_completion=False)
+from .api import PipelineRunner
+from .config import PipelineConfig
+
 console = Console()
+app = typer.Typer(add_completion=False, no_args_is_help=True)
 
 
-@app.command()
-def run(
-    dicom_dir: Path,
-    config: Path,
-    vault: Path,
+def _load_config(path: Optional[Path]) -> PipelineConfig:
+    if path and path.exists():
+        return PipelineConfig.model_validate_json(path.read_text())
+    return PipelineConfig()
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    config: Optional[Path] = typer.Option(None, "--config", "-c", help="Config file"),
     verbose: bool = typer.Option(False, "--verbose", "-v"),
     dry_run: bool = typer.Option(False, "--dry-run"),
-):
+    debug: bool = typer.Option(False, "--debug"),
+) -> None:
+    cfg = _load_config(config)
+    cfg.verbose = verbose
+    cfg.dry_run = dry_run
+    cfg.debug = debug
+    ctx.obj = cfg
+    level = logging.DEBUG if debug else logging.INFO
+    logging.basicConfig(level=level, handlers=[RichHandler(rich_tracebacks=True)])
+
+
+@app.command()
+def run(ctx: typer.Context, dicom_dir: Path, vault: Path) -> None:
     """Execute full pipeline."""
-    conf = PipelineSettings(rules_path=config, verbose=verbose)
-    if dry_run:
-        console.print(f"[yellow]Dry run with config: {conf}")
+    runner = PipelineRunner()
+    cfg: PipelineConfig = ctx.obj
+    if cfg.dry_run:
+        console.print(f"[yellow]Dry run with config: {cfg}")
         raise typer.Exit()
-    result = run_pipeline(dicom_dir, conf, vault)
-    console.print(result)
+    result = runner.run(dicom_dir, cfg, vault)
+    console.print_json(data=result)
 
 
 @app.command()
-def load(dicom_dir: Path):
-    console.print(f"Loading {dicom_dir}")
+def load(ctx: typer.Context, dicom_dir: Path) -> None:
+    runner = PipelineRunner()
+    volume = runner.loader.load_series(dicom_dir)
+    console.print(f"Loaded volume shape {volume.shape}")
 
 
 @app.command()
-def segment(dicom_dir: Path):
-    console.print(f"Segmenting {dicom_dir}")
+def segment(ctx: typer.Context, dicom_dir: Path) -> None:
+    runner = PipelineRunner()
+    volume = runner.loader.load_series(dicom_dir)
+    mask = runner.segmentor.segment(volume)
+    console.print(f"Mask shape: {mask.shape}")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     app()

--- a/msk_io/api.py
+++ b/msk_io/api.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+import time
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Callable, Iterable
+
 import numpy as np
+from prometheus_client import Counter, Summary
+
 from .preprocessing.dicom_loader import DICOMLoader
 from .preprocessing.nifti_converter import NiftiConverter
 from .preprocessing.png_exporter import PNGExporter
@@ -10,7 +16,7 @@ from .symbolic.symbolic_state_emitter import SymbolicStateEmitter, SymbolicState
 from .inference.constraint_lattice import ConstraintLattice
 from .control.multi_agent_harmonizer import MultiAgentHarmonizer, AgentOutput
 from .storage.memory_vault import MemoryVault
-from .config import PipelineSettings
+from .config import PipelineConfig
 from .errors import (
     DICOMLoadError,
     NiftiConversionError,
@@ -22,8 +28,15 @@ from .errors import (
     VaultError,
 )
 
+# Basic Prometheus metrics
+LOAD_TIME = Summary("dicom_load_seconds", "Time spent loading DICOM")
+SEG_TIME = Summary("segment_seconds", "Time spent segmenting")
+VOLUME_COUNTER = Counter("volumes_processed_total", "Volumes processed")
+
 
 class PipelineRunner:
+    """Encapsulates the pipeline execution."""
+
     def __init__(
         self,
         loader: Optional[DICOMLoader] = None,
@@ -35,7 +48,7 @@ class PipelineRunner:
         lattice: Optional[ConstraintLattice] = None,
         harmonizer: Optional[MultiAgentHarmonizer] = None,
         vault: Optional[MemoryVault] = None,
-    ):
+    ) -> None:
         self.loader = loader or DICOMLoader()
         self.converter = converter or NiftiConverter()
         self.exporter = exporter or PNGExporter()
@@ -46,63 +59,85 @@ class PipelineRunner:
         self.harmonizer = harmonizer or MultiAgentHarmonizer()
         self.vault = vault
 
-    def run(self, dicom_dir: Path, config: PipelineSettings, vault_path: Path) -> dict:
-        try:
-            volume = self.loader.load_series(dicom_dir)
-        except Exception as exc:
-            raise DICOMLoadError(str(exc)) from exc
+    def run(self, dicom_dir: Path, config: PipelineConfig, vault_path: Path) -> dict:
+        """Run the pipeline synchronously."""
+        with LOAD_TIME.time():
+            try:
+                volume = self.loader.load_series(dicom_dir)
+            except Exception as exc:  # pragma: no cover - wrapped
+                raise DICOMLoadError(str(exc)) from exc
 
         try:
             nifti_path = self.converter.to_nifti(volume, dicom_dir / "volume.nii.gz")
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover - wrapped
             raise NiftiConversionError(str(exc)) from exc
 
         try:
             self.exporter.save_slice(volume, len(volume) // 2, dicom_dir / "slice.png")
-        except Exception:
+        except Exception:  # pragma: no cover - optional
             pass
 
-        try:
-            mask = self.segmentor.segment(volume)
-        except Exception as exc:
-            raise SegmentationError(str(exc)) from exc
+        with SEG_TIME.time():
+            try:
+                mask = self.segmentor.segment(volume)
+            except Exception as exc:  # pragma: no cover - wrapped
+                raise SegmentationError(str(exc)) from exc
 
         try:
             predicates = self.mapper.map(mask)
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover - wrapped
             raise MappingError(str(exc)) from exc
 
         try:
             state = self.emitter.emit_state(np.array([0.5]), np.array([0.5]))
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover - wrapped
             raise EmissionError(str(exc)) from exc
 
         try:
-            lattice = self.lattice or ConstraintLattice(config.rules_path)
-            valid = lattice.validate_chain([state])
-        except Exception as exc:
+            lattice = (
+                self.lattice or ConstraintLattice(config.lattice.rules_path)
+                if config.lattice
+                else None
+            )
+            valid = lattice.validate_chain([state]) if lattice else True
+        except Exception as exc:  # pragma: no cover - wrapped
             raise ConstraintValidationError(str(exc)) from exc
 
         try:
             final_state = self.harmonizer.harmonize(
                 [AgentOutput(state=state, weight=1.0, agent_id="default")]
             )
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover - wrapped
             raise HarmonizationError(str(exc)) from exc
 
         try:
             vault = self.vault or MemoryVault(vault_path)
             h = vault.checkpoint(final_state)
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover - wrapped
             raise VaultError(str(exc)) from exc
 
+        VOLUME_COUNTER.inc()
         return {
             "nifti": str(nifti_path),
             "valid": valid,
             "hash": h,
+            "predicates": predicates,
         }
 
+    async def run_async(
+        self,
+        dicom_dir: Path,
+        config: PipelineConfig,
+        vault_path: Path,
+        callback: Optional[Callable[[dict], None]] = None,
+    ) -> dict:
+        """Asynchronous wrapper for run."""
+        result = self.run(dicom_dir, config, vault_path)
+        if callback:
+            callback(result)
+        return result
 
-def run_pipeline(dicom_dir: Path, config: PipelineSettings, vault_path: Path) -> dict:
+
+def run_pipeline(dicom_dir: Path, config: PipelineConfig, vault_path: Path) -> dict:
     runner = PipelineRunner()
     return runner.run(dicom_dir, config, vault_path)

--- a/msk_io/config.py
+++ b/msk_io/config.py
@@ -1,22 +1,45 @@
+from __future__ import annotations
+
 from pathlib import Path
 from threading import Thread
-from typing import Callable, Optional
+from typing import Callable, Optional, List
+import os
 
-from pydantic import Field, ValidationError, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator
 from pydantic_settings import BaseSettings
 
 
-class PipelineSettings(BaseSettings):
-    """Pipeline hyperparameters loaded from environment or file."""
+class LoaderConfig(BaseModel):
+    """Configuration for DICOM loading."""
 
-    rules_path: Path = Field(..., description="Path to lattice rules JSON")
+    cache_lmdb: Optional[Path] = None
+    interpolate_missing: bool = False
+
+
+class ConverterConfig(BaseModel):
+    """Settings for NIfTI conversion."""
+
+    embed_metadata: bool = True
+    affine: Optional[List[List[float]]] = None
+
+
+class SegmentorConfig(BaseModel):
+    """Segmentation options."""
+
     threshold: float = Field(0.5, ge=0.0, le=1.0)
-    patch_size: int = Field(64, gt=0)
-    stride: int = Field(32, gt=0)
-    atlas_path: Optional[Path] = None
-    verbose: bool = False
+    model_path: Optional[Path] = None
 
-    model_config = dict(env_prefix="MSK_", extra="ignore")
+
+class MapperConfig(BaseModel):
+    mapping_file: Optional[Path] = None
+
+
+class EmitterConfig(BaseModel):
+    model: str = "default"
+
+
+class LatticeConfig(BaseModel):
+    rules_path: Path = Field(..., alias="rules_path")
 
     @field_validator("rules_path")
     @classmethod
@@ -26,7 +49,59 @@ class PipelineSettings(BaseSettings):
         return v
 
 
-def start_settings_watcher(path: Path, callback: Callable[[PipelineSettings], None]) -> Thread:
+class HarmonizerConfig(BaseModel):
+    policy: str = "weighted"
+
+
+class VaultConfig(BaseModel):
+    path: Path
+
+
+class PipelineConfig(BaseSettings):
+    """Root settings object for the entire pipeline."""
+
+    loader: LoaderConfig = LoaderConfig()
+    converter: ConverterConfig = ConverterConfig()
+    segmentor: SegmentorConfig = SegmentorConfig()
+    mapper: MapperConfig = MapperConfig()
+    emitter: EmitterConfig = EmitterConfig()
+    lattice: Optional[LatticeConfig] = None
+    harmonizer: HarmonizerConfig = HarmonizerConfig()
+    vault: Optional[VaultConfig] = None
+
+    verbose: bool = False
+    dry_run: bool = False
+    debug: bool = False
+
+    model_config = dict(env_prefix="MSK_", extra="ignore", populate_by_name=True)
+
+    def __init__(self, **data):
+        rules_env = os.getenv("MSK_RULES_PATH")
+        if rules_env and "lattice" not in data:
+            data["lattice"] = {"rules_path": rules_env}
+        thresh_env = os.getenv("MSK_THRESHOLD")
+        if thresh_env and "segmentor" not in data:
+            data["segmentor"] = {"threshold": float(thresh_env)}
+        super().__init__(**data)
+
+    @property
+    def rules_path(self) -> Optional[Path]:
+        if self.lattice:
+            return self.lattice.rules_path
+        return None
+
+    @property
+    def threshold(self) -> float:
+        return self.segmentor.threshold
+
+
+# Backwards compatibility
+PipelineSettings = PipelineConfig
+
+
+def start_settings_watcher(
+    path: Path, callback: Callable[[PipelineConfig], None]
+) -> Thread:
     """Start a watchdog thread that reloads settings on file changes."""
     from watchdog.events import FileSystemEventHandler
     from watchdog.observers import Observer
@@ -35,7 +110,7 @@ def start_settings_watcher(path: Path, callback: Callable[[PipelineSettings], No
         def on_modified(self, event):
             if Path(event.src_path) == path:
                 try:
-                    settings = PipelineSettings.model_validate_json(path.read_text())
+                    settings = PipelineConfig.model_validate_json(path.read_text())
                     callback(settings)
                 except ValidationError as exc:
                     print(f"Config reload failed: {exc}")

--- a/msk_io/control/multi_agent_harmonizer.py
+++ b/msk_io/control/multi_agent_harmonizer.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Protocol
+from typing import List, Protocol, Dict, Type
 import numpy as np
 from datetime import datetime
 from ..symbolic.symbolic_state_emitter import SymbolicState
@@ -11,12 +11,26 @@ class AgentOutput:
     weight: float
     agent_id: str = "unknown"
     timestamp: datetime = datetime.utcnow()
+    model_version: str | None = None
+    metadata: dict | None = None
 
 
 class ScoringPolicy(Protocol):
     def score(self, outputs: List[AgentOutput]) -> np.ndarray: ...
 
 
+POLICIES: Dict[str, Type[ScoringPolicy]] = {}
+
+
+def register_policy(name: str):
+    def _decorator(cls: Type[ScoringPolicy]) -> Type[ScoringPolicy]:
+        POLICIES[name] = cls
+        return cls
+
+    return _decorator
+
+
+@register_policy("weighted")
 class WeightedSumPolicy:
     def score(self, outputs: List[AgentOutput]) -> np.ndarray:
         weights = np.array([o.weight for o in outputs], dtype=float)
@@ -25,11 +39,40 @@ class WeightedSumPolicy:
         return weights * scores
 
 
+@register_policy("softmax")
+class SoftmaxPolicy:
+    def score(self, outputs: List[AgentOutput]) -> np.ndarray:
+        conf = np.array([o.state.confidence for o in outputs], dtype=float)
+        e = np.exp(conf)
+        return e / e.sum()
+
+
+@register_policy("bayesian")
+class BayesianFusionPolicy:
+    def score(self, outputs: List[AgentOutput]) -> np.ndarray:
+        conf = np.array([o.state.confidence for o in outputs], dtype=float)
+        return conf / conf.sum() if conf.sum() else conf
+
+
+@register_policy("consensus")
+class ConsensusVotingPolicy:
+    def score(self, outputs: List[AgentOutput]) -> np.ndarray:
+        preds = [tuple(o.state.predicates) for o in outputs]
+        most_common = max(set(preds), key=preds.count)
+        return np.array(
+            [1.0 if tuple(o.state.predicates) == most_common else 0.0 for o in outputs]
+        )
+
+
 class MultiAgentHarmonizer:
     """Combine multiple agent outputs via pluggable scoring."""
 
-    def __init__(self, policy: ScoringPolicy | None = None):
-        self.policy = policy or WeightedSumPolicy()
+    def __init__(self, policy: ScoringPolicy | str | None = None):
+        if isinstance(policy, str):
+            policy_cls = POLICIES.get(policy, WeightedSumPolicy)
+            self.policy = policy_cls()
+        else:
+            self.policy = policy or WeightedSumPolicy()
 
     def harmonize(self, outputs: List[AgentOutput]) -> SymbolicState:
         if not outputs:

--- a/msk_io/errors.py
+++ b/msk_io/errors.py
@@ -1,34 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
 class PipelineError(Exception):
-    """Base class for pipeline errors."""
+    """Base class for pipeline errors with codes and hints."""
+
+    message: str
+    code: str = "PIPELINE_ERROR"
+    severity: str = "error"
+    hint: str | None = None
+
+    def __str__(self) -> str:  # pragma: no cover - string repr
+        return f"{self.code}: {self.message}" + (
+            f" Hint: {self.hint}" if self.hint else ""
+        )
 
 
 class DICOMLoadError(PipelineError):
-    pass
+    code = "DICOM_LOAD_FAILED"
+    hint = "Check input directory for valid DICOM files."
 
 
 class NiftiConversionError(PipelineError):
-    pass
+    code = "NIFTI_CONVERSION_FAILED"
 
 
 class SegmentationError(PipelineError):
-    pass
+    code = "SEGMENTATION_FAILED"
 
 
 class MappingError(PipelineError):
-    pass
+    code = "MAPPING_FAILED"
 
 
 class EmissionError(PipelineError):
-    pass
+    code = "EMISSION_FAILED"
 
 
 class ConstraintValidationError(PipelineError):
-    pass
+    code = "LATTICE_VALIDATION_FAILED"
 
 
 class HarmonizationError(PipelineError):
-    pass
+    code = "HARMONIZATION_FAILED"
 
 
 class VaultError(PipelineError):
-    pass
+    code = "VAULT_FAILED"

--- a/msk_io/preprocessing/dicom_loader.py
+++ b/msk_io/preprocessing/dicom_loader.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Union, List
 import numpy as np
 import pydicom
 
+
 class InvalidDICOMError(Exception):
     """Raised when a file cannot be parsed as DICOM."""
+
 
 class DICOMLoader:
     """Load a series of DICOM slices into a 3D numpy array."""
@@ -20,8 +24,26 @@ class DICOMLoader:
         path = Path(path)
         if not path.exists():
             raise FileNotFoundError(path)
-        files: List[Path] = sorted(path.glob('*.dcm'))
+        files: List[Path] = sorted(path.glob("*.dcm"))
         if not files:
-            raise InvalidDICOMError('No DICOM files found')
-        slices = [self._read_file(f) for f in files]
-        return np.stack(slices)
+            raise InvalidDICOMError("No DICOM files found")
+        slices = []
+        for f in files:
+            arr = self._read_file(f)
+            slices.append((self._slice_key(f), arr))
+        slices.sort(key=lambda x: x[0])
+        volume = np.stack([s[1] for s in slices])
+        return volume
+
+    def _slice_key(self, fp: Path) -> float:
+        try:
+            ds = pydicom.dcmread(str(fp), stop_before_pixels=True)
+            ipp = ds.get("ImagePositionPatient")
+            if ipp:
+                return float(ipp[2])
+            return float(ds.get("InstanceNumber", 0))
+        except Exception:
+            return 0.0
+
+    async def load_series_async(self, path: Union[str, Path]) -> np.ndarray:
+        return self.load_series(path)


### PR DESCRIPTION
## Summary
- expand repo .gitignore and pre-commit settings
- create hierarchical `PipelineConfig`
- rewrite CLI using Typer
- add DI-friendly `PipelineRunner` with metrics
- extend harmonizer with policy registry
- add async-ready DICOM loader
- enrich error types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d5bfb32e0832fa2771f8005282dd1