### PR TITLE
Unify CLI and pipeline settings, add metrics server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,14 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           pip install .[dev]
@@ -17,3 +20,7 @@ jobs:
         run: pre-commit run --files $(git ls-files -m)
       - name: Run tests
         run: pytest -q
+      - name: Build Docker image
+        run: docker build -t msk-io:${{ github.sha }} .
+      - name: Helm preview
+        run: echo "Deploy Helm chart preview"

--- a/.gitignore
+++ b/.gitignore
@@ -89,4 +89,7 @@ pdf_png_cache/
 ocr_cache/
 # CLI logs
 logs/
+logs/*.json
 vector_store/
+.vscode/state/
+docker_state/

--- a/msk_io/api.py
+++ b/msk_io/api.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import time
 from pathlib import Path
 from typing import Callable, Iterable, Optional
 
 import numpy as np
-from prometheus_client import Counter, Summary
+from prometheus_client import Counter, Summary, Gauge, Histogram
+from .decorators import instrument_stage, map_exceptions
 
 from .preprocessing.dicom_loader import DICOMLoader
 from .preprocessing.nifti_converter import NiftiConverter
@@ -35,7 +35,16 @@ from .errors import (
 # Basic Prometheus metrics
 LOAD_TIME = Summary("dicom_load_seconds", "Time spent loading DICOM")
 SEG_TIME = Summary("segment_seconds", "Time spent segmenting")
+MAP_TIME = Summary("map_seconds", "Time spent mapping")
+EMIT_TIME = Summary("emit_seconds", "Time spent emitting")
+VALIDATE_TIME = Summary("validate_seconds", "Time spent validating")
+HARM_TIME = Summary("harmonize_seconds", "Time spent harmonizing")
+VAULT_TIME = Summary("vault_seconds", "Time spent vaulting")
 VOLUME_COUNTER = Counter("volumes_processed_total", "Volumes processed")
+ACTIVE_RUNS = Gauge("active_runs", "Active pipeline runs")
+PREDICATE_HIST = Histogram(
+    "predicates_per_case", "Number of predicates per case", buckets=(1, 2, 5, 10, 20)
+)
 
 
 class PipelineRunner:
@@ -74,62 +83,79 @@ class PipelineRunner:
     def run(self, settings: PipelineSettings, vault: MemoryVault) -> dict:
         """Run the pipeline synchronously."""
         dicom_dir = settings.data_path
-        with LOAD_TIME.time():
-            try:
-                volume = self.loader.load_series(dicom_dir)
-            except Exception as exc:  # pragma: no cover - wrapped
-                raise DICOMLoadError(str(exc), stage="load") from exc
+        ACTIVE_RUNS.inc()
 
-        try:
-            nifti_path = self.converter.to_nifti(volume, dicom_dir / "volume.nii.gz")
-        except Exception as exc:  # pragma: no cover - wrapped
-            raise NiftiConversionError(str(exc), stage="conversion") from exc
+        @instrument_stage("load", LOAD_TIME)
+        @map_exceptions(DICOMLoadError("", stage="load"))
+        def _load() -> np.ndarray:
+            return self.loader.load_series(dicom_dir)
+
+        volume = _load()
+
+        @map_exceptions(NiftiConversionError("", stage="conversion"))
+        def _convert() -> Path:
+            return self.converter.to_nifti(volume, dicom_dir / "volume.nii.gz")
+
+        nifti_path = _convert()
 
         try:
             self.exporter.save_slice(volume, len(volume) // 2, dicom_dir / "slice.png")
         except Exception:  # pragma: no cover - optional
             pass
 
-        with SEG_TIME.time():
-            try:
-                mask = self.segmentor.segment(volume)
-            except Exception as exc:  # pragma: no cover - wrapped
-                raise SegmentationError(str(exc), stage="segmentation") from exc
+        @instrument_stage("segment", SEG_TIME)
+        @map_exceptions(SegmentationError("", stage="segmentation"))
+        def _segment() -> np.ndarray:
+            return self.segmentor.segment(volume)
 
-        try:
-            predicates = self.mapper.map(mask)
-        except Exception as exc:  # pragma: no cover - wrapped
-            raise MappingError(str(exc), stage="mapping") from exc
+        mask = _segment()
 
-        try:
-            state = self.emitter.emit_state(np.array([0.5]), np.array([0.5]))
-        except Exception as exc:  # pragma: no cover - wrapped
-            raise EmissionError(str(exc), stage="emission") from exc
+        @instrument_stage("map", MAP_TIME)
+        @map_exceptions(MappingError("", stage="mapping"))
+        def _map() -> Iterable[str]:
+            return self.mapper.map(mask)
 
-        try:
+        predicates = _map()
+
+        @instrument_stage("emit", EMIT_TIME)
+        @map_exceptions(EmissionError("", stage="emission"))
+        def _emit() -> SymbolicState:
+            return self.emitter.emit_state(np.array([0.5]), np.array([0.5]))
+
+        state = _emit()
+
+        @instrument_stage("validate", VALIDATE_TIME)
+        @map_exceptions(ConstraintValidationError("", stage="validation"))
+        def _validate() -> bool:
             lattice = (
                 self.lattice or ConstraintLattice(settings.lattice.rules_path)
                 if settings.lattice
                 else None
             )
-            valid = lattice.validate_chain([state]) if lattice else True
-        except Exception as exc:  # pragma: no cover - wrapped
-            raise ConstraintValidationError(str(exc), stage="validation") from exc
+            return lattice.validate_chain([state]) if lattice else True
 
-        try:
-            final_state = self.harmonizer.harmonize(
+        valid = _validate()
+
+        @instrument_stage("harmonize", HARM_TIME)
+        @map_exceptions(HarmonizationError("", stage="harmonization"))
+        def _harmonize() -> SymbolicState:
+            return self.harmonizer.harmonize(
                 [AgentOutput(state=state, weight=1.0, agent_id="default")]
             )
-        except Exception as exc:  # pragma: no cover - wrapped
-            raise HarmonizationError(str(exc), stage="harmonization") from exc
 
-        try:
-            vault = self.vault or vault
-            h = vault.checkpoint(final_state)
-        except Exception as exc:  # pragma: no cover - wrapped
-            raise VaultError(str(exc), stage="vault") from exc
+        final_state = _harmonize()
+
+        @instrument_stage("vault", VAULT_TIME)
+        @map_exceptions(VaultError("", stage="vault"))
+        def _vault() -> str:
+            local_vault = self.vault or vault
+            return local_vault.checkpoint(final_state)
+
+        h = _vault()
 
         VOLUME_COUNTER.inc()
+        ACTIVE_RUNS.dec()
+        PREDICATE_HIST.observe(len(list(predicates)))
         return {
             "nifti": str(nifti_path),
             "valid": valid,

--- a/msk_io/config.py
+++ b/msk_io/config.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import os
-from threading import Thread
-from typing import Callable, List, Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -12,6 +11,13 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class LoaderConfig(BaseModel):
     cache_lmdb: Optional[Path] = None
     interpolate_missing: bool = False
+
+    @field_validator("cache_lmdb")
+    @classmethod
+    def validate_cache(cls, v: Optional[Path]) -> Optional[Path]:
+        if v and v.exists() and not v.is_dir():
+            raise ValueError("cache_lmdb must be a directory")
+        return v
 
 
 class ConverterConfig(BaseModel):
@@ -22,6 +28,13 @@ class ConverterConfig(BaseModel):
 class SegmentorConfig(BaseModel):
     threshold: float = Field(0.5, ge=0.0, le=1.0)
     model_path: Optional[Path] = None
+
+    @field_validator("model_path")
+    @classmethod
+    def validate_model(cls, v: Optional[Path]) -> Optional[Path]:
+        if v and not v.exists():
+            raise FileNotFoundError(v)
+        return v
 
 
 class MapperConfig(BaseModel):
@@ -50,6 +63,13 @@ class HarmonizerConfig(BaseModel):
 class VaultConfig(BaseModel):
     path: Path = Path("vault.db")
 
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, v: Path) -> Path:
+        if v.exists() and v.is_dir():
+            raise ValueError("vault path must be a file")
+        return v
+
 
 class PipelineSettings(BaseSettings):
     loader: LoaderConfig = LoaderConfig()
@@ -72,6 +92,13 @@ class PipelineSettings(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="MSK_", extra="ignore")
 
+    @field_validator("data_path")
+    @classmethod
+    def validate_data(cls, v: Path) -> Path:
+        if not v.exists():
+            raise FileNotFoundError(v)
+        return v
+
     def __init__(self, **data):
         rules_env = os.getenv("MSK_RULES_PATH")
         if rules_env and "lattice" not in data:
@@ -92,29 +119,3 @@ class PipelineSettings(BaseSettings):
         return self.segmentor.threshold
 
 
-class SettingsWatcher:
-    def __init__(self, path: Path, callback: Callable[[PipelineSettings], None]):
-        self.path = path
-        self.callback = callback
-        self.thread: Optional[Thread] = None
-
-    def start(self) -> Thread:
-        from watchdog.events import FileSystemEventHandler
-        from watchdog.observers import Observer
-
-        class _Handler(FileSystemEventHandler):
-            def on_modified(self, event):  # type: ignore[override]
-                if Path(event.src_path) == self.path:
-                    try:
-                        settings = PipelineSettings.model_validate_json(
-                            self.path.read_text()
-                        )
-                        self.callback(settings)
-                    except ValidationError as exc:  # pragma: no cover
-                        print(f"Config reload failed: {exc}")
-
-        observer = Observer()
-        observer.schedule(_Handler(), self.path.parent, recursive=False)
-        self.thread = Thread(target=observer.start, daemon=True)
-        self.thread.start()
-        return self.thread

--- a/msk_io/control/multi_agent_harmonizer.py
+++ b/msk_io/control/multi_agent_harmonizer.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
-from typing import List, Protocol, Dict, Type
+from typing import List
 import numpy as np
 from datetime import datetime
 from ..symbolic.symbolic_state_emitter import SymbolicState
+from .policy_registry import POLICIES, ScoringPolicy, register_policy
 
 
 @dataclass
@@ -15,23 +16,11 @@ class AgentOutput:
     metadata: dict | None = None
 
 
-class ScoringPolicy(Protocol):
-    def score(self, outputs: List[AgentOutput]) -> np.ndarray: ...
-
-
-POLICIES: Dict[str, Type[ScoringPolicy]] = {}
-
-
-def register_policy(name: str):
-    def _decorator(cls: Type[ScoringPolicy]) -> Type[ScoringPolicy]:
-        POLICIES[name] = cls
-        return cls
-
-    return _decorator
 
 
 @register_policy("weighted")
 class WeightedSumPolicy:
+    """Weight confidences by provided agent weights."""
     def score(self, outputs: List[AgentOutput]) -> np.ndarray:
         weights = np.array([o.weight for o in outputs], dtype=float)
         weights = weights / weights.sum() if weights.sum() else weights
@@ -41,6 +30,7 @@ class WeightedSumPolicy:
 
 @register_policy("softmax")
 class SoftmaxPolicy:
+    """Apply softmax to agent confidences."""
     def score(self, outputs: List[AgentOutput]) -> np.ndarray:
         conf = np.array([o.state.confidence for o in outputs], dtype=float)
         e = np.exp(conf)
@@ -49,6 +39,7 @@ class SoftmaxPolicy:
 
 @register_policy("bayesian")
 class BayesianFusionPolicy:
+    """Normalize confidences as Bayesian fusion."""
     def score(self, outputs: List[AgentOutput]) -> np.ndarray:
         conf = np.array([o.state.confidence for o in outputs], dtype=float)
         return conf / conf.sum() if conf.sum() else conf
@@ -56,6 +47,7 @@ class BayesianFusionPolicy:
 
 @register_policy("consensus")
 class ConsensusVotingPolicy:
+    """Vote for the most common predicate set."""
     def score(self, outputs: List[AgentOutput]) -> np.ndarray:
         preds = [tuple(o.state.predicates) for o in outputs]
         most_common = max(set(preds), key=preds.count)
@@ -77,6 +69,9 @@ class MultiAgentHarmonizer:
     def harmonize(self, outputs: List[AgentOutput]) -> SymbolicState:
         if not outputs:
             raise ValueError("No agent outputs provided")
+        total_weight = sum(o.weight for o in outputs)
+        if not 0 < total_weight <= 1:
+            raise ValueError("Sum of weights must be within (0,1]")
         scores = self.policy.score(outputs)
         if np.all(scores == 0):
             return outputs[0].state

--- a/msk_io/control/policy_registry.py
+++ b/msk_io/control/policy_registry.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Dict, List, Protocol, Type
+import numpy as np
+
+
+class ScoringPolicy(Protocol):
+    """Strategy interface for scoring agent outputs."""
+
+    def score(self, outputs: List["AgentOutput"]) -> np.ndarray:
+        ...
+
+
+POLICIES: Dict[str, Type[ScoringPolicy]] = {}
+
+
+def register_policy(name: str):
+    """Register a scoring policy by name."""
+
+    def decorator(cls: Type[ScoringPolicy]) -> Type[ScoringPolicy]:
+        POLICIES[name] = cls
+        return cls
+
+    return decorator

--- a/msk_io/decorators.py
+++ b/msk_io/decorators.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import time
+from functools import wraps
+from typing import Any, Callable, Dict
+
+from prometheus_client import Summary
+
+
+def instrument_stage(name: str, summary: Summary) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Measure execution time of a pipeline stage."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            with summary.time():
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def map_exceptions(to_exc: Exception) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Map arbitrary exceptions to a unified error type."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc:  # pragma: no cover - passthrough
+                raise to_exc from exc
+
+        return wrapper
+
+    return decorator
+
+
+def cache_result(ttl: int) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Cache pure function results for ``ttl`` seconds."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        cache: Dict[tuple, tuple] = {}
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            key = (args, tuple(sorted(kwargs.items())))
+            now = time.time()
+            if key in cache:
+                value, ts = cache[key]
+                if now - ts < ttl:
+                    return value
+            result = func(*args, **kwargs)
+            cache[key] = (result, now)
+            return result
+
+        return wrapper
+
+    return decorator

--- a/msk_io/main.py
+++ b/msk_io/main.py
@@ -7,9 +7,13 @@ from typing import Optional
 import typer
 from rich.console import Console
 from rich.logging import RichHandler
+from logging.handlers import RotatingFileHandler
+import logging
+import json
 
 from .api import PipelineRunner
-from .config import PipelineSettings, SettingsWatcher
+from .config import PipelineSettings
+from .metrics_server import create_metrics_app
 from .pdf.pdf_ingestor import MSKPDFIngestor
 from .storage.memory_vault import MemoryVault
 
@@ -23,32 +27,37 @@ def _load_settings(path: Optional[Path]) -> PipelineSettings:
     return PipelineSettings()
 
 
-@app.callback()
+@app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
     config: Optional[Path] = typer.Option(None, "--config", "-c", help="Config file"),
-    log_level: str = typer.Option("INFO", help="Logging level"),
-    metrics_endpoint: Optional[str] = typer.Option(None, "--metrics-endpoint"),
-    vector_db_url: Optional[str] = typer.Option(None, "--vector-db-url"),
+    verbose: bool = typer.Option(False, "--verbose", "-v"),
+    debug: bool = typer.Option(False, "--debug"),
+    dry_run: bool = typer.Option(False, "--dry-run"),
 ) -> None:
     settings = _load_settings(config)
-    settings.log_level = log_level
-    settings.metrics_endpoint = metrics_endpoint
-    settings.vector_db_url = vector_db_url
     ctx.obj = settings
-    level = getattr(logging, settings.log_level.upper(), logging.INFO)
-    logging.basicConfig(level=level, handlers=[RichHandler(rich_tracebacks=True)])
+    log_level = logging.DEBUG if debug or verbose else getattr(logging, settings.log_level.upper(), logging.INFO)
+    handlers = [RichHandler(rich_tracebacks=True)]
+    file_handler = RotatingFileHandler("logs/app.log", maxBytes=10_000_000, backupCount=3)
+    file_handler.setFormatter(
+        logging.Formatter('{"time":"%(asctime)s","level":"%(levelname)s","msg":"%(message)s"}')
+    )
+    handlers.append(file_handler)
+    logging.basicConfig(level=log_level, handlers=handlers, force=True)
+    if dry_run:
+        console.print_json(data=json.loads(settings.model_dump_json()))
+        raise typer.Exit()
 
 
 @app.command()
 def run(ctx: typer.Context, pdf: Optional[Path] = typer.Option(None, "--pdf")) -> None:
+    """Execute the full pipeline."""
     settings: PipelineSettings = ctx.obj
     if pdf:
-        ingestor = MSKPDFIngestor()
-        ingestor.ingest(pdf)
+        MSKPDFIngestor().ingest(pdf)
     vault = MemoryVault(settings.vault.path)
-    runner = PipelineRunner()
-    result = runner.run(settings, vault)
+    result = PipelineRunner().run(settings, vault)
     console.print_json(data=result)
 
 
@@ -73,10 +82,12 @@ def serve(ctx: typer.Context) -> None:
     console.print("Serving (stub)")
 
 
-@app.command("dry-run")
-def dry_run(ctx: typer.Context) -> None:
-    settings: PipelineSettings = ctx.obj
-    console.print(settings)
+@app.command("serve-metrics")
+def serve_metrics(host: str = "0.0.0.0", port: int = 8000) -> None:
+    """Expose Prometheus metrics via Uvicorn."""
+    import uvicorn
+
+    uvicorn.run(create_metrics_app(), host=host, port=port, log_level="info")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/msk_io/metrics_server.py
+++ b/msk_io/metrics_server.py
@@ -1,0 +1,7 @@
+from prometheus_client import make_asgi_app
+
+
+def create_metrics_app():
+    """Return an ASGI app exposing Prometheus metrics."""
+
+    return make_asgi_app()

--- a/msk_io/preprocessing/dicom_loader.py
+++ b/msk_io/preprocessing/dicom_loader.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Union, List
+from typing import Union, List, Tuple
 import numpy as np
 import pydicom
+import lmdb
+import io
+import asyncio
+import logging
 
 
 class InvalidDICOMError(Exception):
@@ -13,12 +17,35 @@ class InvalidDICOMError(Exception):
 class DICOMLoader:
     """Load a series of DICOM slices into a 3D numpy array."""
 
-    def _read_file(self, fp: Path) -> np.ndarray:
+    def __init__(self, cache_lmdb: Path | None = None) -> None:
+        self.cache_lmdb = cache_lmdb
+        self._env = (
+            lmdb.open(str(cache_lmdb), map_size=1_000_000_000)
+            if cache_lmdb
+            else None
+        )
+        self.logger = logging.getLogger(__name__)
+
+    def _read_file(self, fp: Path) -> Tuple[float, np.ndarray] | None:
+        key = str(fp).encode()
+        if self._env:
+            with self._env.begin() as txn:
+                data = txn.get(key)
+                if data:
+                    arr = np.load(io.BytesIO(data))
+                    return self._slice_key(fp), arr
         try:
             ds = pydicom.dcmread(str(fp))
-            return ds.pixel_array
+            arr = ds.pixel_array
+            if self._env:
+                buf = io.BytesIO()
+                np.save(buf, arr)
+                with self._env.begin(write=True) as txn:
+                    txn.put(key, buf.getvalue())
+            return self._slice_key(fp), arr
         except Exception as exc:
-            raise InvalidDICOMError(str(exc)) from exc
+            self.logger.warning("Failed to read %s: %s", fp, exc)
+            return None
 
     def load_series(self, path: Union[str, Path]) -> np.ndarray:
         path = Path(path)
@@ -27,12 +54,21 @@ class DICOMLoader:
         files: List[Path] = sorted(path.glob("*.dcm"))
         if not files:
             raise InvalidDICOMError("No DICOM files found")
-        slices = []
-        for f in files:
-            arr = self._read_file(f)
-            slices.append((self._slice_key(f), arr))
-        slices.sort(key=lambda x: x[0])
-        volume = np.stack([s[1] for s in slices])
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        tasks = [loop.run_in_executor(None, self._read_file, f) for f in files]
+        results = [r for r in loop.run_until_complete(asyncio.gather(*tasks)) if r]
+        loop.close()
+        if not results:
+            raise InvalidDICOMError("All DICOM reads failed")
+        results.sort(key=lambda x: x[0])
+        ipps = [r[0] for r in results]
+        if len(ipps) > 1:
+            spacings = np.diff(sorted(ipps))
+            if np.std(spacings) > 1e-3:
+                self.logger.warning("Inconsistent slice spacing detected")
+        volume = np.stack([r[1] for r in results])
         return volume
 
     def _slice_key(self, fp: Path) -> float:
@@ -46,4 +82,5 @@ class DICOMLoader:
             return 0.0
 
     async def load_series_async(self, path: Union[str, Path]) -> np.ndarray:
-        return self.load_series(path)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.load_series, path)

--- a/msk_io/settings_watcher.py
+++ b/msk_io/settings_watcher.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Thread
+from typing import Callable, Optional
+
+from pydantic import ValidationError
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+from .config import PipelineSettings
+
+
+class SettingsWatcher:
+    """Watch a settings file for changes and hot-reload."""
+
+    def __init__(self, path: Path, callback: Callable[[PipelineSettings], None]):
+        self.path = path
+        self.callback = callback
+        self.thread: Optional[Thread] = None
+
+    def start(self) -> Thread:
+        class _Handler(FileSystemEventHandler):
+            def on_modified(self, event):  # type: ignore[override]
+                if Path(event.src_path) == self.path:
+                    try:
+                        settings = PipelineSettings.model_validate_json(self.path.read_text())
+                        self.callback(settings)
+                    except ValidationError as exc:  # pragma: no cover
+                        print(f"Config reload failed: {exc}")
+
+        observer = Observer()
+        observer.schedule(_Handler(), self.path.parent, recursive=False)
+        self.thread = Thread(target=observer.start, daemon=True)
+        self.thread.start()
+        return self.thread

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pydicom",
     "nibabel",
     "Pillow",
+    "lmdb",
     "typer",
     "pdfminer.six",
     "pytesseract",

--- a/tests/config/test_all_configs.py
+++ b/tests/config/test_all_configs.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+from msk_io.config import PipelineSettings
+
+
+def test_settings_validation(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    settings = PipelineSettings(data_path=data_dir)
+    assert settings.data_path == data_dir

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -8,6 +8,8 @@ def test_env_loading(tmp_path, monkeypatch):
     cfg.write_text(json.dumps({}))
     monkeypatch.setenv("MSK_RULES_PATH", str(cfg))
     monkeypatch.setenv("MSK_THRESHOLD", "0.7")
-    settings = PipelineSettings()
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    settings = PipelineSettings(data_path=data_dir)
     assert settings.rules_path == cfg
     assert settings.threshold == 0.7

--- a/tests/control/test_multi_agent_harmonizer.py
+++ b/tests/control/test_multi_agent_harmonizer.py
@@ -5,6 +5,6 @@ from msk_io.symbolic.symbolic_state_emitter import SymbolicState
 def test_harmonize():
     harmonizer = MultiAgentHarmonizer()
     out1 = AgentOutput(SymbolicState(["a"], 0.9), 0.5, agent_id="A")
-    out2 = AgentOutput(SymbolicState(["b"], 0.6), 1.0, agent_id="B")
+    out2 = AgentOutput(SymbolicState(["b"], 0.6), 0.5, agent_id="B")
     result = harmonizer.harmonize([out1, out2])
     assert result.predicates in (["a"], ["b"])

--- a/tests/control/test_policies.py
+++ b/tests/control/test_policies.py
@@ -1,0 +1,20 @@
+from msk_io.control.policy_registry import POLICIES
+from msk_io.control.multi_agent_harmonizer import (
+    MultiAgentHarmonizer,
+    AgentOutput,
+    WeightedSumPolicy,
+)
+from msk_io.symbolic.symbolic_state_emitter import SymbolicState
+
+
+def test_policy_registry():
+    assert "weighted" in POLICIES
+    assert issubclass(POLICIES["weighted"], WeightedSumPolicy)
+
+
+def test_harmonizer_weights():
+    harmonizer = MultiAgentHarmonizer()
+    out1 = AgentOutput(SymbolicState(["a"], 0.8), 0.4)
+    out2 = AgentOutput(SymbolicState(["b"], 0.9), 0.6)
+    result = harmonizer.harmonize([out1, out2])
+    assert result in (out1.state, out2.state)

--- a/tests/metrics/test_metrics_server.py
+++ b/tests/metrics/test_metrics_server.py
@@ -1,0 +1,6 @@
+from msk_io.metrics_server import create_metrics_app
+
+
+def test_metrics_app():
+    app = create_metrics_app()
+    assert callable(app)


### PR DESCRIPTION
## Summary
- clean up repo ignores
- provide policy registry and decorators helpers
- add metrics server app
- refactor CLI with better logging and global options
- enhance DICOM loader with async reading and caching
- instrument pipeline stages with metrics
- add settings watcher utility
- update tests and CI matrix

## Testing
- `pre-commit run --files $(git ls-files -m)` *(fails: HTTP 403 fetching hooks)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d60c2bdc0832fbbaf4e4490f7725b