### PR TITLE
Add main CLI entry and DL segmentation

### DIFF
--- a/msk_io/__main__.py
+++ b/msk_io/__main__.py
@@ -1,0 +1,4 @@
+from .main import app
+
+if __name__ == "__main__":
+    app()

--- a/msk_io/image_processing/__init__.py
+++ b/msk_io/image_processing/__init__.py
@@ -1,0 +1,7 @@
+"""Image processing utilities."""
+
+from .segmentor import Segmentor
+from .dl_segmentor import DLSegmentor
+from .constraint_mapper import ConstraintMapper
+
+__all__ = ["Segmentor", "DLSegmentor", "ConstraintMapper"]

--- a/msk_io/image_processing/dl_segmentor.py
+++ b/msk_io/image_processing/dl_segmentor.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+from .segmentor import Segmentor
+
+try:  # pragma: no cover - optional dependency
+    import onnxruntime as ort
+except Exception:  # pragma: no cover - fallback
+    ort = None
+
+
+class DLSegmentor(Segmentor):
+    """Deep learning segmentor with optional ONNX runtime."""
+
+    def __init__(self, model_path: Optional[Path] = None, threshold: float = 0.5):
+        super().__init__(threshold=threshold)
+        self.model_path = model_path
+        if model_path and ort:
+            self.session = ort.InferenceSession(str(model_path))
+        else:  # pragma: no cover - fallback
+            self.session = None
+
+    def segment(self, volume: np.ndarray) -> np.ndarray:  # type: ignore[override]
+        if self.session:
+            input_name = self.session.get_inputs()[0].name
+            output = self.session.run(None, {input_name: volume[None].astype(np.float32)})[0]
+            mask = output.argmax(axis=0).astype(np.uint8)
+        else:
+            mask = super().segment(volume)
+        # simple small object removal
+        labels, counts = np.unique(mask, return_counts=True)
+        for label, count in zip(labels, counts):
+            if label != 0 and count < 10:
+                mask[mask == label] = 0
+        return mask

--- a/msk_io/main.py
+++ b/msk_io/main.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from prometheus_client import make_asgi_app
+from rich.console import Console
+from rich.logging import RichHandler
+from logging.handlers import RotatingFileHandler
+
+
+from .api import PipelineRunner, PipelineResult
+from .config import PipelineSettings
+from .storage.memory_vault import MemoryVault
+from .pdf.pdf_ingestor import MSKPDFIngestor
+
+console = Console()
+app = typer.Typer(add_completion=False, no_args_is_help=True)
+
+
+def create_logger(level: int) -> None:
+    logger = logging.getLogger()
+    logger.handlers.clear()
+    fmt = (
+        '{"time":"%(asctime)s","level":"%(levelname)s","correlation":"%(correlation)s","msg":"%(message)s"}'
+    )
+    correlation = str(uuid.uuid4())[:8]
+
+    class CorrelationFilter(logging.Filter):
+        def filter(self, record: logging.LogRecord) -> bool:
+            record.correlation = correlation
+            return True
+
+    rich_handler = RichHandler(rich_tracebacks=True)
+    file_handler = RotatingFileHandler(
+        "logs/app.log", maxBytes=5_000_000, backupCount=2
+    )
+    for h in (rich_handler, file_handler):
+        h.setFormatter(logging.Formatter(fmt))
+        h.addFilter(CorrelationFilter())
+        logger.addHandler(h)
+    logger.setLevel(level)
+
+
+def _load_settings(path: Optional[Path]) -> PipelineSettings:
+    if path and path.exists():
+        return PipelineSettings.model_validate_json(path.read_text())
+    return PipelineSettings()
+
+
+@app.callback(invoke_without_command=True)
+def main(
+    ctx: typer.Context,
+    config: Optional[str] = typer.Option(None, "--config", "-c", help="Config file"),
+    pdf: Optional[str] = typer.Option(None, "--pdf", help="PDF to ingest"),
+    data_path: Optional[str] = typer.Option(None, "--data-path"),
+    vector_db_url: Optional[str] = typer.Option(None, "--vector-db-url"),
+    ocr_enabled: bool = typer.Option(False, "--ocr-enabled", is_flag=True),
+    log_level: str = typer.Option("INFO", "--log-level"),
+    dry_run: bool = typer.Option(False, "--dry-run"),
+) -> None:
+    settings = _load_settings(Path(config) if config else None)
+    overrides = {}
+    if pdf is not None:
+        overrides["pdf_path"] = Path(pdf)
+    if data_path is not None:
+        overrides["data_path"] = Path(data_path)
+    if vector_db_url is not None:
+        overrides["vector_db_url"] = vector_db_url
+    if ocr_enabled is not None:
+        overrides["ocr_enabled"] = ocr_enabled
+    if log_level:
+        overrides["log_level"] = log_level
+    if overrides:
+        settings = settings.model_copy(update=overrides)
+    ctx.obj = settings
+    level = getattr(logging, settings.log_level.upper(), logging.INFO)
+    create_logger(level)
+    if dry_run:
+        console.print_json(data=json.loads(settings.model_dump_json()))
+        raise typer.Exit()
+
+
+@app.command()
+def ingest(ctx: typer.Context) -> None:
+    """Ingest a PDF specified in the loaded settings."""
+    settings: PipelineSettings = ctx.obj
+    if not settings.pdf_path:
+        typer.echo("PDF path not provided", err=True)
+        raise typer.Exit(code=1)
+    texts = MSKPDFIngestor().ingest(settings.pdf_path)
+    for t in texts:
+        console.print(t)
+
+
+@app.command()
+def run(ctx: typer.Context) -> None:
+    settings: PipelineSettings = ctx.obj
+    vault = MemoryVault(settings.vault.path)
+    result = PipelineRunner().run(settings, vault)
+    console.print_json(data=result.__dict__)
+
+
+@app.command()
+def index(ctx: typer.Context, items: List[str]) -> None:
+    """Index arbitrary text items."""
+    settings: PipelineSettings = ctx.obj
+    runner = PipelineRunner()
+    runner.indexer.index_items(items)
+    typer.echo(f"Indexed {len(items)} items")
+
+
+@app.command()
+def serve(ctx: typer.Context, host: str = "0.0.0.0", port: int = 8000) -> None:
+    settings: PipelineSettings = ctx.obj
+    runner = PipelineRunner()
+    api_app = FastAPI()
+
+    @api_app.post("/rpc")
+    async def rpc(payload: dict) -> JSONResponse:  # type: ignore[valid-type]
+        if payload.get("method") == "run":
+            res: PipelineResult = await runner.run_async(
+                settings, MemoryVault(settings.vault.path)
+            )
+            return JSONResponse(res.__dict__)
+        return JSONResponse({"error": "unknown method"}, status_code=400)
+
+    api_app.mount("/metrics", make_asgi_app())
+
+    import uvicorn
+
+    uvicorn.run(api_app, host=host, port=port, log_level="info")
+
+
+@app.command("serve-metrics")
+def serve_metrics(host: str = "0.0.0.0", port: int = 8000) -> None:
+    import uvicorn
+
+    uvicorn.run(make_asgi_app(), host=host, port=port, log_level="info")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/tests/image_processing/test_dl_segmentor.py
+++ b/tests/image_processing/test_dl_segmentor.py
@@ -1,0 +1,9 @@
+import numpy as np
+from msk_io.image_processing.dl_segmentor import DLSegmentor
+
+
+def test_dl_segmentor_segment():
+    volume = np.random.rand(2, 2, 2).astype(np.float32)
+    seg = DLSegmentor()
+    mask = seg.segment(volume)
+    assert mask.shape == volume.shape

--- a/tests/test_main_module.py
+++ b/tests/test_main_module.py
@@ -1,0 +1,8 @@
+import subprocess
+import sys
+
+
+def test_module_invocation():
+    result = subprocess.run([sys.executable, '-m', 'msk_io', '--help'], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert 'Usage' in result.stdout


### PR DESCRIPTION
## Summary
- introduce `msk_io/main.py` with new `ingest` and `index` commands
- add `msk_io/__main__.py` module entry point
- implement `DLSegmentor` for optional ONNX-based inference
- expose new segmentor via `msk_io.image_processing`
- test module invocation and DLSegmentor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d68f1f510832f8a98538438afd666