### PR TITLE
Introduce multi-agent volume analysis

### DIFF
--- a/msk_io/api.py
+++ b/msk_io/api.py
@@ -14,6 +14,13 @@ from .preprocessing.png_exporter import PNGExporter
 from .image_processing.segmentor import Segmentor
 from .image_processing.constraint_mapper import ConstraintMapper
 from .symbolic.symbolic_state_emitter import SymbolicStateEmitter, SymbolicState
+from .inference.llm_agents import (
+    BaseAgent,
+    MiniGPTAgent,
+    GEMAAgent,
+    PHI2Agent,
+    analyze_with_agents,
+)
 from .inference.constraint_lattice import ConstraintLattice
 from .control.multi_agent_harmonizer import MultiAgentHarmonizer, AgentOutput
 from .storage.memory_vault import MemoryVault
@@ -67,6 +74,7 @@ class PipelineRunner:
         ocr: Optional[OCRExtractor] = None,
         indexer: Optional[SemanticIndexer] = None,
         retriever: Optional[ConstraintRetriever] = None,
+        agents: Optional[Iterable[BaseAgent]] = None,
     ) -> None:
         self.loader = loader or DICOMLoader()
         self.converter = converter or NiftiConverter()
@@ -81,6 +89,14 @@ class PipelineRunner:
         self.ocr = ocr or OCRExtractor()
         self.indexer = indexer or SemanticIndexer(Path("index"))
         self.retriever = retriever or ConstraintRetriever(self.indexer)
+        if agents is None:
+            self.agents = [
+                MiniGPTAgent(weight=1 / 3),
+                GEMAAgent(weight=1 / 3),
+                PHI2Agent(weight=1 / 3),
+            ]
+        else:
+            self.agents = list(agents)
 
     def run(self, settings: PipelineSettings, vault: MemoryVault) -> PipelineResult:
         """Run the pipeline synchronously."""
@@ -121,10 +137,11 @@ class PipelineRunner:
 
         @instrument_stage("emit")
         @map_exceptions(EmissionError("", stage="emission"))
-        def _emit() -> SymbolicState:
-            return self.emitter.emit_state(np.array([0.5]), np.array([0.5]))
+        def _emit() -> list[AgentOutput]:
+            return analyze_with_agents(volume, self.agents)
 
-        state = _emit()
+        outputs = _emit()
+        states = [o.state for o in outputs]
 
         @instrument_stage("validate")
         @map_exceptions(ConstraintValidationError("", stage="validation"))
@@ -134,16 +151,14 @@ class PipelineRunner:
                 if settings.lattice
                 else None
             )
-            return lattice.validate_chain([state]) if lattice else True
+            return lattice.validate_chain(states) if lattice else True
 
         valid = _validate()
 
         @instrument_stage("harmonize")
         @map_exceptions(HarmonizationError("", stage="harmonization"))
         def _harmonize() -> SymbolicState:
-            return self.harmonizer.harmonize(
-                [AgentOutput(state=state, weight=1.0, agent_id="default")]
-            )
+            return self.harmonizer.harmonize(outputs)
 
         final_state = _harmonize()
 

--- a/msk_io/control/multi_agent_harmonizer.py
+++ b/msk_io/control/multi_agent_harmonizer.py
@@ -69,9 +69,6 @@ class MultiAgentHarmonizer:
     def harmonize(self, outputs: List[AgentOutput]) -> SymbolicState:
         if not outputs:
             raise ValueError("No agent outputs provided")
-        total_weight = sum(o.weight for o in outputs)
-        if not 0 < total_weight <= 1:
-            raise ValueError("Sum of weights must be within (0,1]")
         scores = self.policy.score(outputs)
         if np.all(scores == 0):
             return outputs[0].state

--- a/msk_io/inference/llm_agents.py
+++ b/msk_io/inference/llm_agents.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+import numpy as np
+
+from ..symbolic.symbolic_state_emitter import SymbolicStateEmitter, SymbolicState
+
+
+@dataclass
+class BaseAgent:
+    """Base class for simple volume analysis agents."""
+
+    name: str = ""
+    weight: float = 1.0
+    model_version: str = "0"
+    emitter: SymbolicStateEmitter | None = None
+
+    def __post_init__(self) -> None:
+        if self.emitter is None:
+            self.emitter = SymbolicStateEmitter()
+
+    def analyze_volume(self, volume: np.ndarray) -> SymbolicState:
+        """Return a symbolic state using the mean pixel intensity."""
+        mean_val = float(volume.mean())
+        emb = np.array([mean_val / (volume.max() or 1.0)])
+        return self.emitter.emit_state(emb, emb)
+
+
+class MiniGPTAgent(BaseAgent):
+    name = "miniGPT"
+
+
+class GEMAAgent(BaseAgent):
+    name = "GEMA"
+
+
+class PHI2Agent(BaseAgent):
+    name = "PHI-2"
+
+import asyncio
+from typing import Iterable, List
+from ..control.multi_agent_harmonizer import AgentOutput
+
+
+def analyze_with_agents(volume: np.ndarray, agents: Iterable[BaseAgent]) -> List[AgentOutput]:
+    """Run agents concurrently over the volume."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    tasks = [loop.run_in_executor(None, a.analyze_volume, volume) for a in agents]
+    states = loop.run_until_complete(asyncio.gather(*tasks))
+    loop.close()
+    outputs = [
+        AgentOutput(state=s, weight=a.weight, agent_id=a.name, model_version=a.model_version)
+        for a, s in zip(agents, states)
+    ]
+    return outputs


### PR DESCRIPTION
## Summary
- add new `llm_agents` module with lightweight agent stubs
- remove weight sum restriction from `MultiAgentHarmonizer`
- update `PipelineRunner` to run miniGPT, GEMA and PHI‑2 agents concurrently
- provide default agents when none supplied

## Testing
- `pip install -q numpy pydantic pydicom nibabel Pillow lmdb typer pdfminer.six pytesseract watchdog`
- `pip install -q pydantic-settings prometheus_client fastapi`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686d6dfdf5fc832fa4899c89e14d0656