### PR TITLE
Add orientation checks in DICOM loader

### DIFF
--- a/msk_io/preprocessing/dicom_loader.py
+++ b/msk_io/preprocessing/dicom_loader.py
@@ -15,7 +15,12 @@ class InvalidDICOMError(Exception):
 
 
 class DICOMLoader:
-    """Load a series of DICOM slices into a 3D numpy array."""
+    """Load a series of DICOM slices into a 3D numpy array.
+
+    The loader attempts to verify basic alignment by ensuring that slice
+    orientations are consistent across the series. Any detected mismatch is
+    logged as a warning but does not stop loading.
+    """
 
     def __init__(self, cache_lmdb: Path | None = None) -> None:
         self.cache_lmdb = cache_lmdb
@@ -25,6 +30,30 @@ class DICOMLoader:
             else None
         )
         self.logger = logging.getLogger(__name__)
+
+    def _slice_orientation(self, fp: Path) -> Tuple[float, ...] | None:
+        """Return the ImageOrientationPatient tuple if present."""
+        try:
+            ds = pydicom.dcmread(str(fp), stop_before_pixels=True)
+            iop = ds.get("ImageOrientationPatient")
+            if iop:
+                return tuple(float(x) for x in iop)
+        except Exception:
+            pass
+        return None
+
+    def _check_orientation(self, paths: List[Path]) -> None:
+        """Log a warning if orientations differ significantly."""
+        orientations = [self._slice_orientation(p) for p in paths]
+        valid = [o for o in orientations if o]
+        if len(valid) <= 1:
+            return
+        base = np.array(valid[0])
+        for orient in valid[1:]:
+            diff = np.linalg.norm(np.array(orient) - base)
+            if diff > 1e-3:
+                self.logger.warning("Inconsistent slice orientation detected")
+                break
 
     def _read_file(self, fp: Path) -> Tuple[float, np.ndarray] | None:
         key = str(fp).encode()
@@ -68,6 +97,7 @@ class DICOMLoader:
             spacings = np.diff(sorted(ipps))
             if np.std(spacings) > 1e-3:
                 self.logger.warning("Inconsistent slice spacing detected")
+        self._check_orientation(files)
         volume = np.stack([r[1] for r in results])
         return volume
 

--- a/tests/preprocessing/test_dicom_loader.py
+++ b/tests/preprocessing/test_dicom_loader.py
@@ -17,8 +17,31 @@ def test_load_series(tmp_path: Path):
     ds.HighBit = 15
     ds.PixelRepresentation = 0
     ds.Rows, ds.Columns = arr.shape
+    ds.ImagePositionPatient = [0, 0, 0]
+    ds.ImageOrientationPatient = [1, 0, 0, 0, 1, 0]
     ds.save_as(tmp_path / 'slice.dcm')
 
     loader = DICOMLoader()
     volume = loader.load_series(tmp_path)
     assert volume.shape == (1, 10, 10)
+
+
+def test_slice_orientation(tmp_path: Path) -> None:
+    arr = (np.random.rand(5, 5) * 255).astype(np.uint16)
+    file_meta = pydicom.dataset.FileMetaDataset()
+    file_meta.TransferSyntaxUID = pydicom.uid.ImplicitVRLittleEndian
+    ds = pydicom.dataset.FileDataset('test', {}, file_meta=file_meta, preamble=b"\0" * 128)
+    ds.PixelData = arr.tobytes()
+    ds.SamplesPerPixel = 1
+    ds.PhotometricInterpretation = "MONOCHROME2"
+    ds.BitsAllocated = 16
+    ds.BitsStored = 16
+    ds.HighBit = 15
+    ds.PixelRepresentation = 0
+    ds.Rows, ds.Columns = arr.shape
+    ds.ImageOrientationPatient = [1, 0, 0, 0, 1, 0]
+    p = tmp_path / 'slice.dcm'
+    ds.save_as(p)
+    loader = DICOMLoader()
+    orient = loader._slice_orientation(p)
+    assert orient == (1.0, 0.0, 0.0, 0.0, 1.0, 0.0)


### PR DESCRIPTION
## Summary
- verify orientation consistency when loading DICOM series
- extend unit tests for DICOMLoader with orientation metadata
- add a unit test for the private `_slice_orientation` helper

## Testing
- `pre-commit run --files msk_io/preprocessing/dicom_loader.py tests/preprocessing/test_dicom_loader.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686da271a630832f8740e51d56e9193b