### PR TITLE
Add universal loader and parallel slice executor

### DIFF
--- a/msk_io/image_processing/parallel_executor.py
+++ b/msk_io/image_processing/parallel_executor.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
+from typing import Callable
+import asyncio
+import numpy as np
+
+
+def process_slices(volume: np.ndarray, func: Callable[[np.ndarray], np.ndarray], *, workers: int | None = None, backend: str = "thread") -> list[np.ndarray]:
+    """Apply ``func`` to each slice of ``volume`` concurrently."""
+    executor_cls = ThreadPoolExecutor if backend == "thread" else ProcessPoolExecutor
+    with executor_cls(max_workers=workers) as exe:
+        futures = [exe.submit(func, volume[i]) for i in range(volume.shape[0])]
+        return [f.result() for f in futures]
+
+
+async def process_slices_async(volume: np.ndarray, func: Callable[[np.ndarray], np.ndarray], *, workers: int | None = None, backend: str = "thread") -> list[np.ndarray]:
+    """Asynchronous variant of :func:`process_slices`."""
+    loop = asyncio.get_running_loop()
+    executor_cls = ThreadPoolExecutor if backend == "thread" else ProcessPoolExecutor
+    with executor_cls(max_workers=workers) as exe:
+        tasks = [loop.run_in_executor(exe, func, volume[i]) for i in range(volume.shape[0])]
+        return await asyncio.gather(*tasks)

--- a/msk_io/preprocessing/universal_loader.py
+++ b/msk_io/preprocessing/universal_loader.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+from PIL import Image
+import nibabel as nib
+
+from .dicom_loader import DICOMLoader
+
+
+class UniversalLoader:
+    """Load medical images from various formats."""
+
+    def __init__(self, dicom_loader: DICOMLoader | None = None) -> None:
+        self.dicom_loader = dicom_loader or DICOMLoader()
+
+    def load(self, path: Union[str, Path]) -> np.ndarray:
+        """Load an image volume or array from ``path``.
+
+        * Directories are treated as DICOM series.
+        * ``.nii`` or ``.nii.gz`` files are loaded via ``nibabel``.
+        * ``.png``/``.jpg`` files return a 2D array.
+        """
+        p = Path(path)
+        if p.is_dir():
+            return self.dicom_loader.load_series(p)
+        suffix = p.suffix.lower()
+        if suffix == ".nii" or str(p).lower().endswith(".nii.gz"):
+            nifti = nib.load(str(p))
+            data = nifti.get_fdata()
+            return np.asarray(data)
+        if suffix in {".png", ".jpg", ".jpeg"}:
+            img = Image.open(p)
+            return np.array(img)
+        raise ValueError(f"Unsupported format: {p}")

--- a/tests/image_processing/test_parallel_executor.py
+++ b/tests/image_processing/test_parallel_executor.py
@@ -1,0 +1,24 @@
+import asyncio
+import numpy as np
+from msk_io.image_processing.parallel_executor import (
+    process_slices,
+    process_slices_async,
+)
+
+
+def _sum(slice_: np.ndarray) -> np.ndarray:
+    return np.array([slice_.sum()])
+
+
+def test_process_slices() -> None:
+    vol = np.arange(12).reshape(3, 2, 2)
+    res = process_slices(vol, _sum)
+    assert len(res) == 3
+    assert res[0] == np.array([0 + 1 + 2 + 3])[:1]
+
+
+def test_process_slices_async() -> None:
+    vol = np.arange(8).reshape(2, 2, 2)
+    res = asyncio.run(process_slices_async(vol, _sum))
+    assert len(res) == 2
+    assert res[1] == np.array([4 + 5 + 6 + 7])[:1]

--- a/tests/preprocessing/test_universal_loader.py
+++ b/tests/preprocessing/test_universal_loader.py
@@ -1,0 +1,62 @@
+import numpy as np
+import pydicom
+from pathlib import Path
+from PIL import Image
+import nibabel as nib
+
+from msk_io.preprocessing.universal_loader import UniversalLoader
+
+
+def _create_dicom(path: Path) -> Path:
+    arr = (np.random.rand(8, 8) * 255).astype(np.uint16)
+    file_meta = pydicom.dataset.FileMetaDataset()
+    file_meta.TransferSyntaxUID = pydicom.uid.ImplicitVRLittleEndian
+    ds = pydicom.dataset.FileDataset("test", {}, file_meta=file_meta, preamble=b"\0" * 128)
+    ds.PixelData = arr.tobytes()
+    ds.SamplesPerPixel = 1
+    ds.PhotometricInterpretation = "MONOCHROME2"
+    ds.BitsAllocated = 16
+    ds.BitsStored = 16
+    ds.HighBit = 15
+    ds.PixelRepresentation = 0
+    ds.Rows, ds.Columns = arr.shape
+    ds.ImagePositionPatient = [0, 0, 0]
+    ds.ImageOrientationPatient = [1, 0, 0, 0, 1, 0]
+    ds.save_as(path / "slice.dcm")
+    return path
+
+
+def _create_nifti(path: Path) -> Path:
+    data = np.random.rand(2, 2, 2)
+    nifti = nib.Nifti1Image(data, affine=np.eye(4))
+    out = path / "volume.nii.gz"
+    nib.save(nifti, str(out))
+    return out
+
+
+def _create_png(path: Path) -> Path:
+    img = Image.new("L", (4, 4), color=0)
+    out = path / "img.png"
+    img.save(out)
+    return out
+
+
+def test_load_dicom(tmp_path: Path) -> None:
+    dicom_dir = _create_dicom(tmp_path)
+    loader = UniversalLoader()
+    vol = loader.load(dicom_dir)
+    assert vol.shape == (1, 8, 8)
+
+
+def test_load_nifti(tmp_path: Path) -> None:
+    nifti = _create_nifti(tmp_path)
+    loader = UniversalLoader()
+    vol = loader.load(nifti)
+    assert vol.shape == (2, 2, 2)
+
+
+def test_load_png(tmp_path: Path) -> None:
+    img = _create_png(tmp_path)
+    loader = UniversalLoader()
+    arr = loader.load(img)
+    assert arr.shape == (4, 4)


### PR DESCRIPTION
## Summary
- implement `UniversalLoader` for reading DICOM folders, NIfTI and PNG/JPEG
- add `process_slices` utility for concurrent slice processing
- test the universal loader and parallel executor

## Testing
- `pytest tests/preprocessing/test_universal_loader.py tests/image_processing/test_parallel_executor.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686db1239d04832f89a23cbebd5bea68