### PR TITLE
Expand test coverage

### DIFF
--- a/tests/config/test_invalid_params.py
+++ b/tests/config/test_invalid_params.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+import pytest
+from pydantic import ValidationError
+from msk_io.config import PipelineSettings
+
+
+def test_invalid_threshold(tmp_path: Path):
+    cfg = tmp_path / 'settings.json'
+    cfg.write_text(json.dumps({'segmentor': {'threshold': -0.1}, 'data_path': str(tmp_path)}))
+    with pytest.raises(ValidationError):
+        PipelineSettings.model_validate_json(cfg.read_text())
+
+
+def test_env_override(tmp_path: Path, monkeypatch):
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir()
+    rules = tmp_path / 'rules.json'
+    rules.write_text(json.dumps({}))
+    monkeypatch.setenv('MSK_RULES_PATH', str(rules))
+    settings = PipelineSettings(data_path=data_dir)
+    assert settings.rules_path == rules

--- a/tests/control/test_harmonize_contradictions.py
+++ b/tests/control/test_harmonize_contradictions.py
@@ -1,0 +1,13 @@
+from msk_io.control.multi_agent_harmonizer import MultiAgentHarmonizer, AgentOutput
+from msk_io.symbolic.symbolic_state_emitter import SymbolicState
+
+
+def test_harmonize_contradictory():
+    harmonizer = MultiAgentHarmonizer()
+    outputs = [
+        AgentOutput(SymbolicState(["bone_marrow_edema"], 0.8), 0.3, agent_id="A"),
+        AgentOutput(SymbolicState(["normal_marrow"], 0.7), 0.3, agent_id="B"),
+        AgentOutput(SymbolicState(["synovitis"], 0.6), 0.4, agent_id="C"),
+    ]
+    state = harmonizer.harmonize(outputs)
+    assert state.predicates in (["bone_marrow_edema"], ["normal_marrow"], ["synovitis"])

--- a/tests/image_processing/test_segmentation_metrics.py
+++ b/tests/image_processing/test_segmentation_metrics.py
@@ -1,0 +1,14 @@
+import numpy as np
+from msk_io.image_processing.segmentor import Segmentor
+
+
+def _dice(a: np.ndarray, b: np.ndarray) -> float:
+    inter = np.logical_and(a, b).sum()
+    return 2 * inter / float(a.sum() + b.sum()) if (a.sum() + b.sum()) else 1.0
+
+
+def test_segmentation_dice() -> None:
+    vol = np.array([[[0, 1], [1, 0]]], dtype=np.uint8)
+    seg = Segmentor(threshold=0.5)
+    mask = seg.segment(vol)
+    assert _dice(mask, vol) == 1.0

--- a/tests/integration/test_pipeline_with_lattice.py
+++ b/tests/integration/test_pipeline_with_lattice.py
@@ -1,0 +1,38 @@
+import json
+import numpy as np
+import pydicom
+from pathlib import Path
+from msk_io.api import PipelineRunner
+from msk_io.config import PipelineSettings
+from msk_io.storage.memory_vault import MemoryVault
+
+
+def _create_series(path: Path) -> None:
+    arr = np.full((5, 5), 250, dtype=np.uint16)
+    meta = pydicom.dataset.FileMetaDataset()
+    meta.TransferSyntaxUID = pydicom.uid.ImplicitVRLittleEndian
+    ds = pydicom.dataset.FileDataset('test', {}, file_meta=meta, preamble=b"\0" * 128)
+    ds.PixelData = arr.tobytes()
+    ds.SamplesPerPixel = 1
+    ds.PhotometricInterpretation = 'MONOCHROME2'
+    ds.BitsAllocated = 16
+    ds.BitsStored = 16
+    ds.HighBit = 15
+    ds.PixelRepresentation = 0
+    ds.Rows, ds.Columns = arr.shape
+    ds.ImagePositionPatient = [0, 0, 0]
+    ds.save_as(path / 'slice.dcm')
+
+
+def test_pipeline_with_lattice(tmp_path: Path) -> None:
+    data = tmp_path / 'data'
+    data.mkdir()
+    _create_series(data)
+    rules = tmp_path / 'rules.json'
+    rules.write_text(json.dumps({'required_predicates': ['positive'], 'allowed_predicates': ['positive', 'negative']}))
+    settings = PipelineSettings(data_path=data, lattice={'rules_path': rules})
+    vault = MemoryVault(tmp_path / 'db.sqlite')
+    result = PipelineRunner().run(settings, vault)
+    assert result.valid
+    assert result.predicates
+

--- a/tests/preprocessing/test_dicom_series_loader.py
+++ b/tests/preprocessing/test_dicom_series_loader.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pydicom
+from pathlib import Path
+from msk_io.preprocessing.dicom_loader import DICOMLoader
+
+
+def _create_series(path: Path, count: int) -> None:
+    for i in range(count):
+        arr = (np.random.rand(5, 5) * 255).astype(np.uint16)
+        meta = pydicom.dataset.FileMetaDataset()
+        meta.TransferSyntaxUID = pydicom.uid.ImplicitVRLittleEndian
+        ds = pydicom.dataset.FileDataset("test", {}, file_meta=meta, preamble=b"\0" * 128)
+        ds.PixelData = arr.tobytes()
+        ds.SamplesPerPixel = 1
+        ds.PhotometricInterpretation = "MONOCHROME2"
+        ds.BitsAllocated = 16
+        ds.BitsStored = 16
+        ds.HighBit = 15
+        ds.PixelRepresentation = 0
+        ds.Rows, ds.Columns = arr.shape
+        ds.InstanceNumber = i
+        ds.ImagePositionPatient = [0, 0, float(i)]
+        ds.save_as(path / f"slice_{i}.dcm")
+
+
+def test_load_multiple_slices(tmp_path: Path) -> None:
+    _create_series(tmp_path, 3)
+    loader = DICOMLoader()
+    volume = loader.load_series(tmp_path)
+    assert volume.shape == (3, 5, 5)

--- a/tests/symbolic/test_state_emission_features.py
+++ b/tests/symbolic/test_state_emission_features.py
@@ -1,0 +1,12 @@
+import numpy as np
+from msk_io.symbolic.symbolic_state_emitter import SymbolicStateEmitter, SymbolicState
+
+
+def test_emit_numerical_state() -> None:
+    emitter = SymbolicStateEmitter()
+    text_emb = np.array([0.2, 0.8])
+    img_emb = np.array([0.7, 0.9])
+    state = emitter.emit_state(text_emb, img_emb)
+    assert isinstance(state, SymbolicState)
+    assert state.predicates
+    assert 0.0 <= state.confidence <= 1.0


### PR DESCRIPTION
## Summary
- add validation tests for PipelineSettings
- add harmonizer test with contradictory agent states
- test DICOMLoader with multiple slices
- evaluate segmentation output using Dice metric
- test symbolic state emitter
- verify pipeline run against lattice rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686db53d43d4832f86fe23300eae9d08