### PR TITLE
Add Chromium bootstrap scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,11 @@ a headless browser. ``DICOMStreamSniffer`` monitors network traffic to
 download the original DICOM payloads. ``RemoteDICOMLoader`` combines both
 methods and is triggered when ``remote_url`` and ``auth_token`` are set in
 ``PipelineSettings``.
+
+## Local Chromium Setup
+
+Some utilities rely on a headless Chromium browser. Run `./bootstrap_chromium.sh`
+to ensure a compatible binary is available. The script checks for a system
+installation and unpacks `resources/chromium/chromium.tar.xz` when needed. A
+Python helper (`bootstrap_chromium.py`) provides the same behavior for
+restricted environments.

--- a/bootstrap_chromium.py
+++ b/bootstrap_chromium.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Fallback helper to unpack a local Chromium archive.
+
+Run by bootstrap_chromium.sh when a system Chromium is absent.
+"""
+import os
+import shutil
+import sys
+import tarfile
+from pathlib import Path
+
+CHROMIUM_CMDS = ["chromium-browser", "chromium", "google-chrome"]
+
+def chromium_exists() -> bool:
+    for cmd in CHROMIUM_CMDS:
+        if shutil.which(cmd):
+            print(f"Chromium available via {cmd}")
+            return True
+    return False
+
+
+def main(res_dir: str) -> None:
+    if chromium_exists():
+        return
+
+    archive = Path(res_dir) / "chromium.tar.xz"
+    out_dir = Path(res_dir) / "bin"
+
+    if archive.is_file():
+        print(f"Extracting {archive} to {out_dir}")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(archive) as tf:
+            tf.extractall(out_dir)
+        os.environ["PATH"] = str(out_dir) + os.pathsep + os.environ.get("PATH", "")
+        if chromium_exists():
+            print("Chromium extracted and available")
+            return
+        print("Extraction finished but chromium command still missing", file=sys.stderr)
+    else:
+        print(f"Chromium archive {archive} not found", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    resources = sys.argv[1] if len(sys.argv) > 1 else os.path.join(os.path.dirname(__file__), "resources", "chromium")
+    main(resources)

--- a/bootstrap_chromium.sh
+++ b/bootstrap_chromium.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Bootstrap Chromium by extracting a local archive if a system install is missing.
+set -e
+
+CHROMIUM_CMDS=("chromium-browser" "chromium" "google-chrome")
+
+for cmd in "${CHROMIUM_CMDS[@]}"; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+        echo "Chromium already available via $cmd"
+        exit 0
+    fi
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RES_DIR="$SCRIPT_DIR/resources/chromium"
+ARCHIVE="$RES_DIR/chromium.tar.xz"
+
+if [ -f "$ARCHIVE" ]; then
+    echo "Unpacking Chromium from $ARCHIVE"
+    mkdir -p "$RES_DIR/bin"
+    tar -xf "$ARCHIVE" -C "$RES_DIR/bin" --strip-components=1
+    export PATH="$RES_DIR/bin:$PATH"
+    echo "Chromium unpacked to $RES_DIR/bin"
+    exit 0
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+    python3 "$SCRIPT_DIR/bootstrap_chromium.py" "$RES_DIR"
+else
+    echo "chromium not found and no Python fallback available" >&2
+    exit 1
+fi

--- a/resources/chromium/README.md
+++ b/resources/chromium/README.md
@@ -1,0 +1,3 @@
+Place a compressed Chromium archive named 'chromium.tar.xz' in this directory.
+The bootstrap scripts will extract it to 'resources/chromium/bin' when no system
+Chromium install is detected.


### PR DESCRIPTION
## Summary
- add `bootstrap_chromium.sh` to provision Chromium from a local archive
- add Python fallback `bootstrap_chromium.py`
- document Chromium bootstrap usage in README
- add a placeholder README in `resources/chromium`

## Testing
- `./run_tests.sh` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_686e86f00e10832fa6a373a108042d23