### PR TITLE
Add quickstart docs and update setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,41 @@ MSK_REMOTE_URL="https://nbia.cancerimagingarchive.net/viewer/?study=..." \
 MSK_AUTH_TOKEN="eyJhbGciOiJI..." \
 python bootstrap_pipeline.py
 ```
+
+## Quickstart
+
+The following steps reproduce the offline pipeline described in the project whitepaper. They assume a Linux environment:
+
+1. Create and activate a virtual environment:
+
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+
+2. Install dependencies. Prefer the editable install but fall back to the minimal list when the optional extras are unavailable:
+
+   ```bash
+   pip install -e .[dev] || \
+   pip install pydantic-settings prometheus-client httpx fastapi numpy pydicom lmdb pillow nibabel pdfminer.six pyppeteer
+   ```
+
+3. Place a compatible `chromium.tar.xz` inside `resources/chromium/` if the system has no network access. Then bootstrap the browser with:
+
+   ```bash
+   ./bootstrap_chromium.sh  # or `python bootstrap_chromium.py`
+   ```
+
+4. Run the test suite to confirm the environment works:
+
+   ```bash
+   ./run_tests.sh
+   ```
+
+5. Export the remote OHIF url and token and launch the pipeline:
+
+   ```bash
+   export MSK_REMOTE_URL="https://nbia.example/viewer/123"
+   export MSK_AUTH_TOKEN="<jwt-token>"
+   python bootstrap_pipeline.py
+   ```

--- a/full_setup.sh
+++ b/full_setup.sh
@@ -15,7 +15,12 @@ source "$VENV_DIR/bin/activate"
 
 # --- Install requirements ---
 pip install --upgrade pip
-pip install typer fastapi prometheus_client numpy pydicom lmdb pillow httpx nibabel pdfminer.six pydantic-settings pyppeteer
+if ! pip install -e .[dev]; then
+    pip install pydantic-settings prometheus-client httpx fastapi numpy pydicom lmdb pillow nibabel pdfminer.six pyppeteer
+fi
+
+# --- Run tests ---
+./run_tests.sh
 
 # --- Validate Chromium setup ---
 if ! command -v chromium-browser &> /dev/null && [ ! -f "$CHROMIUM_ARCHIVE" ]; then


### PR DESCRIPTION
## Summary
- document environment setup and pipeline invocation in README
- run tests from `full_setup.sh` and add dependency fallback

## Testing
- `./run_tests.sh`
- `python bootstrap_pipeline.py` *(fails: chromium archive not found)*

------
https://chatgpt.com/codex/tasks/task_b_686eb0d795cc832fb3e1afdaac0df454