### PR TITLE
Fix dependencies for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ dependencies = [
     "faiss-cpu",
     "watchdog",
     "uvicorn[standard]",
+    "pydantic-settings",
+    "fastapi",
+    "prometheus-client",
+    "httpx",
 ]
 
 [project.optional-dependencies]

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -18,3 +18,7 @@ mypy==1.9.0
 pre-commit==3.6.2
 bandit==1.7.5
 safety==2.3.5
+pydantic-settings==2.10.1
+fastapi==0.116.0
+prometheus-client==0.22.1
+httpx==0.28.1


### PR DESCRIPTION
## Summary
- add pydantic-settings, fastapi, prometheus-client and httpx to dependencies
- lock versions in requirements-lock.txt

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_686ebe8e8ed0832f846139d46acbe014