### PR TITLE
Add OCR and text reasoning features

### DIFF
--- a/msk_io/api.py
+++ b/msk_io/api.py
@@ -21,6 +21,7 @@ from .inference.llm_agents import (
     MiniGPTAgent,
     GEMAAgent,
     PHI2Agent,
+    TextAgent,
     analyze_with_agents,
 )
 from .inference.constraint_lattice import ConstraintLattice
@@ -28,6 +29,7 @@ from .control.multi_agent_harmonizer import MultiAgentHarmonizer, AgentOutput
 from .storage.memory_vault import MemoryVault
 from .pdf.pdf_loader import PDFLoader
 from .ocr.ocr_extractor import OCRExtractor
+from .pdf.pdf_ingestor import MSKPDFIngestor
 from .indexer.semantic_indexer import SemanticIndexer
 from .retrieval.constraint_retriever import ConstraintRetriever
 from .config import PipelineSettings
@@ -84,7 +86,7 @@ class PipelineRunner:
         self.converter = converter or NiftiConverter()
         self.exporter = exporter or PNGExporter()
         self.segmentor = segmentor or Segmentor()
-        self.mapper = mapper or ConstraintMapper({1: "region"})
+        self.mapper = mapper or ConstraintMapper({1: "positive", 0: "negative"})
         self.emitter = emitter or SymbolicStateEmitter()
         self.lattice = lattice
         self.harmonizer = harmonizer or MultiAgentHarmonizer()
@@ -107,6 +109,14 @@ class PipelineRunner:
         """Run the pipeline synchronously."""
         dicom_dir = settings.data_path
         ACTIVE_RUNS.inc()
+        texts: List[str] = []
+        if settings.pdf_path and settings.pdf_path.exists():
+            ingestor = MSKPDFIngestor(self.pdf_loader, self.ocr)
+            texts = ingestor.ingest(settings.pdf_path, ocr_enabled=settings.ocr_enabled)
+            if texts:
+                self.indexer.add_items(texts)
+                if self.vault:
+                    self.vault.add_knowledge(texts)
 
         @instrument_stage("load")
         @map_exceptions(DICOMLoadError("", stage="load"))
@@ -146,7 +156,10 @@ class PipelineRunner:
         @instrument_stage("emit")
         @map_exceptions(EmissionError("", stage="emission"))
         def _emit() -> list[AgentOutput]:
-            return analyze_with_agents(volume, self.agents)
+            agents = self.agents
+            if texts:
+                agents = list(self.agents) + [TextAgent(self.indexer, weight=1 / (len(self.agents) + 1))]
+            return analyze_with_agents(volume, agents)
 
         outputs = _emit()
         states = [o.state for o in outputs]

--- a/msk_io/inference/llm_agents.py
+++ b/msk_io/inference/llm_agents.py
@@ -38,6 +38,26 @@ class GEMAAgent(BaseAgent):
 class PHI2Agent(BaseAgent):
     name = "PHI-2"
 
+
+class TextAgent(BaseAgent):
+    """Simple agent that reasons over indexed text."""
+
+    name = "text"
+
+    def __init__(self, indexer, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.indexer = indexer
+
+    def analyze_volume(self, volume: np.ndarray) -> SymbolicState:
+        text = " ".join(getattr(self.indexer, "items", []))
+        lowered = text.lower()
+        keywords = ["mass", "lesion", "abnormal"]
+        if any(k in lowered for k in keywords):
+            return SymbolicState(["positive"], 0.9)
+        if text:
+            return SymbolicState(["negative"], 0.9)
+        return SymbolicState(["negative"], 0.5)
+
 import asyncio
 from typing import Iterable, List
 from ..control.multi_agent_harmonizer import AgentOutput

--- a/msk_io/ocr/ocr_extractor.py
+++ b/msk_io/ocr/ocr_extractor.py
@@ -2,27 +2,35 @@ from __future__ import annotations
 
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Tuple
+from typing import List, Tuple, Union
+import io
 
 
 class OCRExtractor:
     """OCR extractor using pytesseract with simple batching."""
 
-    def _extract_one(self, path: Path) -> Tuple[str, float]:
+    def _extract_one(self, source: Union[Path, bytes]) -> Tuple[str, float]:
         try:
             import pytesseract
             from PIL import Image
 
-            text = pytesseract.image_to_string(Image.open(path))
+            if isinstance(source, Path):
+                img = Image.open(source)
+            else:  # bytes
+                img = Image.open(io.BytesIO(source))
+            text = pytesseract.image_to_string(img)
             conf = 0.9
         except Exception:
-            text = path.stem
+            text = source.stem if isinstance(source, Path) else ""
             conf = 0.5
         return text, conf
 
     def extract(self, path: Path) -> str:
         return self._extract_one(path)[0]
 
-    def extract_batch(self, paths: List[Path]) -> List[Tuple[str, float]]:
+    def extract_bytes(self, data: bytes) -> str:
+        return self._extract_one(data)[0]
+
+    def extract_batch(self, paths: List[Union[Path, bytes]]) -> List[Tuple[str, float]]:
         with ThreadPoolExecutor() as ex:
             return list(ex.map(self._extract_one, paths))

--- a/msk_io/pdf/pdf_ingestor.py
+++ b/msk_io/pdf/pdf_ingestor.py
@@ -12,7 +12,14 @@ class MSKPDFIngestor:
         self.loader = loader or PDFLoader()
         self.ocr = ocr or OCRExtractor()
 
-    def ingest(self, path: Path) -> List[str]:
+    def ingest(self, path: Path, ocr_enabled: bool = False) -> List[str]:
         pages = self.loader.load(path)
-        texts = [p.text for p in pages]
+        texts: List[str] = []
+        for page in pages:
+            text = page.text.strip()
+            if ocr_enabled and (not text or len(text) < 5) and page.images:
+                ocr_texts = [self.ocr.extract_bytes(img.data) for img in page.images]
+                if ocr_texts:
+                    text = " ".join(ocr_texts)
+            texts.append(text)
         return texts

--- a/msk_io/storage/memory_vault.py
+++ b/msk_io/storage/memory_vault.py
@@ -13,6 +13,9 @@ class MemoryVault:
         self.conn.execute(
             'CREATE TABLE IF NOT EXISTS states (hash TEXT PRIMARY KEY, data TEXT)'
         )
+        self.conn.execute(
+            'CREATE TABLE IF NOT EXISTS knowledge (id INTEGER PRIMARY KEY AUTOINCREMENT, text TEXT)'
+        )
 
     def checkpoint(self, state: SymbolicState) -> str:
         h = str(abs(hash(tuple(state.predicates))))
@@ -28,3 +31,8 @@ class MemoryVault:
             raise KeyError(h)
         data = json.loads(row[0])
         return SymbolicState(predicates=data['predicates'], confidence=data['confidence'])
+
+    def add_knowledge(self, texts: list[str]) -> None:
+        for text in texts:
+            self.conn.execute('INSERT INTO knowledge (text) VALUES (?)', (text,))
+        self.conn.commit()


### PR DESCRIPTION
## Summary
- integrate OCR text extraction in PDF ingestion
- add TextAgent for simple text-based inference
- store ingested knowledge in `MemoryVault`
- update default constraint mapping
- adjust pipeline to use ingested text and TextAgent if PDF provided

## Testing
- `pre-commit` *(fails: error fetching hooks)*
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_686eca0af170832f9e364dd3253b8e8a