### PR TITLE
Enhance pipeline resilience

### DIFF
--- a/bootstrap_chromium.py
+++ b/bootstrap_chromium.py
@@ -13,7 +13,9 @@ CHROMIUM_CMDS = ["chromium-browser", "chromium", "google-chrome"]
 
 def chromium_exists() -> bool:
     for cmd in CHROMIUM_CMDS:
-        if shutil.which(cmd):
+        path = shutil.which(cmd)
+        if path:
+            os.environ.setdefault("PYPPETEER_EXECUTABLE_PATH", path)
             print(f"Chromium available via {cmd}")
             return True
     return False
@@ -32,7 +34,9 @@ def main(res_dir: str) -> None:
         with tarfile.open(archive) as tf:
             tf.extractall(out_dir)
         os.environ["PATH"] = str(out_dir) + os.pathsep + os.environ.get("PATH", "")
-        if chromium_exists():
+        cand = shutil.which("chromium") or shutil.which("chromium-browser") or shutil.which("google-chrome")
+        if cand:
+            os.environ.setdefault("PYPPETEER_EXECUTABLE_PATH", cand)
             print("Chromium extracted and available")
             return
         print("Extraction finished but chromium command still missing", file=sys.stderr)

--- a/msk_io/preprocessing/nifti_converter.py
+++ b/msk_io/preprocessing/nifti_converter.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Union
+import warnings
 import numpy as np
 import nibabel as nib
 
@@ -8,6 +9,13 @@ class NiftiConverter:
 
     def to_nifti(self, volume: np.ndarray, out_path: Union[str, Path]) -> Path:
         out_path = Path(out_path)
-        nifti = nib.Nifti1Image(volume, affine=np.eye(4))
+        try:
+            nifti = nib.Nifti1Image(volume, affine=np.eye(4))
+        except Exception as exc:
+            warnings.warn(f"Conversion failed ({exc}); using fallback", RuntimeWarning)
+            arr = np.asarray(volume, dtype=np.float32)
+            if arr.ndim == 2:
+                arr = arr[..., None]
+            nifti = nib.Nifti1Image(arr, affine=np.zeros((4, 4)))
         nib.save(nifti, str(out_path))
         return out_path

--- a/msk_io/retrieval/remote_loader.py
+++ b/msk_io/retrieval/remote_loader.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 """High level loader that combines canvas capture and network sniffing."""
 
 import asyncio
+import json
 import logging
-from typing import Optional
+import time
+from pathlib import Path
+from typing import Optional, Dict
 
 import numpy as np
 
@@ -20,18 +23,44 @@ class RemoteDICOMLoader:
     def __init__(self, slices: int = 1) -> None:
         self.slices = slices
 
+    def _dump_state(self, method: str, start: float, errors: Dict[str, str]) -> None:
+        data = {
+            "method": method,
+            "start": start,
+            "end": time.time(),
+            "errors": errors,
+        }
+        try:
+            Path("volume_retrieval.json").write_text(json.dumps(data))
+        except Exception:  # pragma: no cover - diagnostics only
+            pass
+
     async def _load_async(self, url: str, token: Optional[str]) -> np.ndarray:
+        errors: Dict[str, str] = {}
+        start = time.time()
+        method = "canvas"
         try:
             canvas = OHIFCanvasExtractor(url, token, slices=self.slices)
             volume = await canvas.retrieve()
             if volume.ndim == 3:
+                self._dump_state(method, start, errors)
                 return volume
+            errors[method] = "unexpected_shape"
             logger.warning("Canvas capture returned unexpected shape")
         except Exception as exc:  # pragma: no cover - best effort
+            errors[method] = str(exc)
             logger.warning("Canvas capture failed: %s", exc)
-        sniffer = DICOMStreamSniffer(url, token)
-        volume = await sniffer.retrieve()
-        return volume
+
+        method = "sniffer"
+        try:
+            sniffer = DICOMStreamSniffer(url, token)
+            volume = await sniffer.retrieve()
+            self._dump_state(method, start, errors)
+            return volume
+        except Exception as exc:
+            errors[method] = str(exc)
+            self._dump_state(method, start, errors)
+            raise
 
     def load(self, url: str, token: Optional[str] = None) -> np.ndarray:
         """Synchronous wrapper for :meth:`_load_async`."""

--- a/processa_dicom.py
+++ b/processa_dicom.py
@@ -4,8 +4,39 @@ from __future__ import annotations
 
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
+import base64
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
 
 import typer
+
+
+@dataclass
+class TokenStatus:
+    """Record how the authentication token was sourced and validated."""
+
+    source: str
+    expired: bool | None = None
+
+
+def _check_expiration(token: str) -> bool | None:
+    """Return True if expired, False if valid, None if undecodable."""
+    try:
+        payload_b64 = token.split(".")[1]
+        # Pad base64 if necessary
+        pad = len(payload_b64) % 4
+        if pad:
+            payload_b64 += "=" * (4 - pad)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64).decode())
+        exp = payload.get("exp")
+        if exp is None:
+            return None
+        return datetime.now(timezone.utc).timestamp() > exp
+    except Exception:
+        return None
 
 from msk_io.preprocessing.nifti_converter import NiftiConverter
 from msk_io.retrieval.remote_loader import RemoteDICOMLoader
@@ -15,15 +46,30 @@ app = typer.Typer(add_completion=False)
 
 @app.command()
 def main(
-    url: str, out: str = "volume.nii.gz", token: str | None = None, slices: int = 1
+    url: str,
+    out: str = "volume.nii.gz",
+    token: str | None = None,
+    slices: int = 1,
 ) -> None:
     """Fetch ``url`` and save the volume to ``out``."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
+
+    status = TokenStatus(source="url")
     if token is None:
         qs = parse_qs(urlparse(url).query)
         token = qs.get("token", [None])[0]
+    if not token:
+        token = os.environ.get("MSK_AUTH_TOKEN")
+        status.source = "env"
+        if not token:
+            logging.warning("No authentication token provided")
+    status.expired = _check_expiration(token) if token else None
+
     loader = RemoteDICOMLoader(slices=slices)
     volume = loader.load(url, token)
     path = NiftiConverter().to_nifti(volume, Path(out))
+    with open("token_status.json", "w") as f:
+        json.dump(status.__dict__, f)
     typer.echo(f"Saved {path}")
 
 


### PR DESCRIPTION
## Summary
- add token status tracking and env fallback for token
- log volume retrieval method with errors
- make nifti conversion more tolerant to bad volumes
- set `PYPPETEER_EXECUTABLE_PATH` in `bootstrap_chromium.py`

## Testing
- `./run_tests.sh` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_686edc96db44832f849b9aa0a08a14d6