### PR TITLE
Enable offline pipeline fallbacks

### DIFF
--- a/msk_io/retrieval/remote_loader.py
+++ b/msk_io/retrieval/remote_loader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Optional, Dict
@@ -59,9 +60,22 @@ class RemoteDICOMLoader:
             return volume
         except Exception as exc:
             errors[method] = str(exc)
-            self._dump_state(method, start, errors)
-            raise
+            logger.warning("Sniffer failed: %s", exc)
+
+        fallback = os.environ.get("MSK_FALLBACK_VOLUME")
+        if fallback:
+            try:
+                volume = np.load(fallback)
+                self._dump_state("offline", start, errors)
+                logger.warning("Using offline volume %s", fallback)
+                return volume
+            except Exception as exc:  # pragma: no cover - ignore
+                errors["offline"] = str(exc)
+
+        logger.warning("Falling back to synthetic volume")
+        self._dump_state("synthetic", start, errors)
+        return np.zeros((self.slices, 10, 10), dtype=np.uint16)
 
     def load(self, url: str, token: Optional[str] = None) -> np.ndarray:
-        """Synchronous wrapper for :meth:`_load_async`."""
+        """Synchronous wrapper for :meth:`_load_async` with offline fallback."""
         return asyncio.run(self._load_async(url, token))

--- a/processa_dicom.py
+++ b/processa_dicom.py
@@ -10,6 +10,7 @@ import logging
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import Optional
 
 import typer
 
@@ -46,16 +47,21 @@ app = typer.Typer(add_completion=False)
 
 @app.command()
 def main(
-    url: str,
+    url: Optional[str] = None,
     out: str = "volume.nii.gz",
-    token: str | None = None,
+    token: Optional[str] = None,
     slices: int = 1,
 ) -> None:
     """Fetch ``url`` and save the volume to ``out``."""
     logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
 
+    if url is None:
+        url = os.environ.get("MSK_REMOTE_URL")
+        if not url:
+            raise typer.BadParameter("URL must be provided via argument or MSK_REMOTE_URL")
+        logging.warning("Using MSK_REMOTE_URL environment variable")
     status = TokenStatus(source="url")
-    if token is None:
+    if token is None and url:
         qs = parse_qs(urlparse(url).query)
         token = qs.get("token", [None])[0]
     if not token:


### PR DESCRIPTION
## Summary
- allow `processa_dicom.py` to read URL from the `MSK_REMOTE_URL` environment variable and use Optional annotations
- add synthetic/offline fallback volume to `RemoteDICOMLoader`

## Testing
- `./run_tests.sh`
- `python processa_dicom.py --slices 2`

------
https://chatgpt.com/codex/tasks/task_b_686edfc6486c832f863228cea219897d