### PR TITLE
Add env file loading and semantic indexer tests

### DIFF
--- a/msk_io/config.py
+++ b/msk_io/config.py
@@ -75,9 +75,34 @@ class AppConfig(BaseSettings):
                 logger.error(f"Failed to create directory {path}: {e}")
                 raise ConfigurationError(f"Required directory creation failed: {path}") from e
 
-def load_config() -> AppConfig:
+def load_config(env_file: str | None = None) -> AppConfig:
+    """Load and return the application configuration.
+
+    Parameters
+    ----------
+    env_file : str | None, optional
+        Path to a ``.env`` file. If ``None``, a file named ``.env`` in the
+        current working directory is used. The ``MSKIO_APP_ENV_FILE`` environment
+        variable takes precedence if set.
+    """
+
+    if env_file is None:
+        env_file = os.environ.get("MSKIO_APP_ENV_FILE", os.path.join(os.getcwd(), ".env"))
+
+    if os.path.exists(env_file):
+        try:
+            with open(env_file) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    key, value = line.split("=", 1)
+                    os.environ.setdefault(key, value)
+        except OSError as e:
+            logger.warning(f"Failed to read env file {env_file}: {e}")
+
     try:
-        config = AppConfig()
+        config = AppConfig(_env_file=None)
         return config
     except ValidationError as e:
         logger.error(f"Configuration validation error: {e}")

--- a/tests/test_semantic_indexer.py
+++ b/tests/test_semantic_indexer.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from msk_io.indexer.semantic_indexer import SemanticIndexer
+
+
+@pytest.fixture
+def indexer_instance(test_config):
+    return SemanticIndexer(test_config)
+
+
+def test_index_document_creates_file(indexer_instance, tmp_path):
+    doc_id = 'test_doc'
+    text = 'some text'
+    indexer_instance.vector_db_path = str(tmp_path / 'db')
+    indexer_instance.index_document(doc_id, text, {'meta': 'data'})
+    out_file = f'{indexer_instance.vector_db_path}_{doc_id}.txt'
+    assert os.path.exists(out_file)
+
+
+def test_query_semantic_index_returns_results(indexer_instance):
+    results = indexer_instance.query_semantic_index('test query', top_k=1)
+    assert isinstance(results, list)
+    assert len(results) == 1


### PR DESCRIPTION
## Summary
- support custom env file loading in `load_config`
- add a basic test suite for `SemanticIndexer`

## Testing
- `pytest -q tests/test_semantic_indexer.py tests/test_config.py::test_app_config_loads_from_dot_env_file -q`

------
https://chatgpt.com/codex/tasks/task_b_6876ae0c3d60832f91436dada2d6ce59